### PR TITLE
Fix rank colors and health

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 | ----------------------------- | --------------------------------------------------------------- |
 | **System name**               | **MyRPG**                                                       |
 | **Foundry VTT compatibility** | v12 (tested on 12.324)                                          |
-| **Current version (**``**)**  | `2.204` → **auto‑bumped to** `2.205` on next commit             |
+| **Current version (**``**)**  | `2.206` -> **auto-bumped to** `2.207` on next commit             |
 | **Languages**                 | 🇬🇧 English, 🇷🇺 Русский (full parity required)               |
 | **Main tech**                 | ES‑module JavaScript (`*.mjs`), Handlebars (`*.hbs`), JSON, CSS |
 | **Licence**                   | MIT (source) / CC BY‑SA 4.0 (game rules)                        |

--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -845,6 +845,31 @@ input.rank5 {
   border-color: #5fa8d3;
   color: #000;
 }
+.skill-name.rank1, th.rank1 {
+  background-color: #c7e6b3;
+  border-color: #6dbb32;
+  color: #000;
+}
+.skill-name.rank2, th.rank2 {
+  background-color: #cd7f32;
+  border-color: #cd7f32;
+  color: #000;
+}
+.skill-name.rank3, th.rank3 {
+  background-color: #c0c0c0;
+  border-color: #c0c0c0;
+  color: #000;
+}
+.skill-name.rank4, th.rank4 {
+  background-color: #d4af37;
+  border-color: #d4af37;
+  color: #000;
+}
+.skill-name.rank5, th.rank5 {
+  background-color: #5fa8d3;
+  border-color: #5fa8d3;
+  color: #000;
+}
 .rank1-bg { background-color: #6dbb32; color: #1b1210; }
 .rank2-bg { background-color: #cd7f32; color: #1b1210; }
 .rank3-bg { background-color: #c0c0c0; color: #1b1210; }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -27,8 +27,8 @@ export class myrpgActor extends Actor {
 
     /* 3. Производные параметры ------------------------------------ */
     s.speed.value = this._calcSpeed(s);
-    // health is not auto-calculated
-    s.health.max = s.health.max ?? 20;
+    // health max derives from base 20 plus bonuses
+    s.health.max = this._calcHealthMax(s);
     s.health.value = Math.min(s.health.value ?? s.health.max, s.health.max);
     s.flux.value = this._calcFlux(s);
     s.defenses = {

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -18,5 +18,9 @@ export function getRankAndDie(val = 0) {
  * @returns {number} Rank between 1 and 5
  */
 export function getColorRank(val = 0) {
-  return Math.min(5, Math.floor((val - 1) / 2) + 1);
+  if (val <= 2) return 1;
+  if (val <= 4) return 2;
+  if (val <= 6) return 3;
+  if (val <= 8) return 4;
+  return 5;
 }

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.206",
+  "version": "2.207",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -96,11 +96,10 @@
                   <tr>
                     {{#each system.abilities as |ability key|}}
                       <th
-                        class='rollable'
+                        class='rollable {{ability.rankClass}}'
                         data-ability='{{key}}'
                         data-label='{{ability.label}}'
-                        class='{{ability.rankClass}}'
-                        >{{ability.label}}</th>
+                      >{{ability.label}}</th>
                     {{/each}}
                   </tr>
                 </thead>
@@ -200,6 +199,8 @@
                     value='{{system.health.max}}'
                     step='1'
                     inputmode='numeric'
+                    readonly
+                    tabindex='-1'
                   />
                 </div>
               </div>

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -40,6 +40,8 @@
               name='system.health.max'
               value='{{system.health.max}}'
               data-dtype='Number'
+              readonly
+              tabindex='-1'
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- calculate health max including bonuses
- colour attribute headers and skill names based on rank
- lock max health fields
- tweak color ranking function
- update version to 2.207 and AGENTS guide

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68653876f230832e85ce6fa3beee11dd