### PR TITLE
Update rank visuals and labels

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -832,10 +832,10 @@ input.rank2 {
   border-color: #cd7f32 !important;
   color: #000;
 }
-.rank3 { color: #c0c0c0; }
+.rank3 { color: #d8d8d8; }
 input.rank3 {
-  background-color: #c0c0c0 !important;
-  border-color: #c0c0c0 !important;
+  background-color: #d8d8d8 !important;
+  border-color: #d8d8d8 !important;
   color: #000;
 }
 .rank4 { color: #d4af37; }
@@ -861,8 +861,8 @@ input.rank5 {
   color: #000;
 }
 .skill-name.rank3 {
-  background-color: #c0c0c0;
-  border-color: #c0c0c0;
+  background-color: #d8d8d8;
+  border-color: #d8d8d8;
   color: #000;
 }
 .skill-name.rank4 {
@@ -877,6 +877,6 @@ input.rank5 {
 }
 .rank1-bg { background-color: #6dbb32; color: #1b1210; }
 .rank2-bg { background-color: #cd7f32; color: #1b1210; }
-.rank3-bg { background-color: #c0c0c0; color: #1b1210; }
+.rank3-bg { background-color: #d8d8d8; color: #1b1210; }
 .rank4-bg { background-color: #d4af37; color: #1b1210; }
 .rank5-bg { background-color: #5fa8d3; color: #1b1210; }

--- a/lang/en.json
+++ b/lang/en.json
@@ -17,11 +17,11 @@
     },
     "RankGradient": {
       "Title": "Rank Gradient",
-      "Rank1": "Rank 1",
-      "Rank2": "Rank 2",
-      "Rank3": "Rank 3",
-      "Rank4": "Rank 4",
-      "Rank5": "Rank 5"
+      "Rank1": "Wood",
+      "Rank2": "Bronze",
+      "Rank3": "Silver",
+      "Rank4": "Gold",
+      "Rank5": "Sky"
     },
     "KeyInfo": {
       "Calling": "Calling",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -22,11 +22,11 @@
     },
     "RankGradient": {
       "Title": "Градация рангов",
-      "Rank1": "1 ранг",
-      "Rank2": "2 ранг",
-      "Rank3": "3 ранг",
-      "Rank4": "4 ранг",
-      "Rank5": "5 ранг"
+      "Rank1": "дерево",
+      "Rank2": "бронза",
+      "Rank3": "серебро",
+      "Rank4": "золото",
+      "Rank5": "небо"
     },
     "ArmorItem": {
       "ArmorSectionTitle": "Доспех",

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.210",
+  "version": "2.211",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
## Summary
- lighten the silver rank color
- rename ranks to Wood/Bronze/Silver/Gold/Sky
- bump version to 2.211

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 404 Not Found for prettier-plugin-handlebars)*

------
https://chatgpt.com/codex/tasks/task_e_68654b0cd87c832ebb807d4bf0c4f1b2