### PR TITLE
feat: add minimal bonus roll rule

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -115,6 +115,7 @@
     "TempSpeed": {
       "Label": "Temp. Speed"
     },
+    "MinimalBonus": "minimal bonus",
     "abilityAbbreviations": {
       "spi": "Spi",
       "con": "Body",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -115,6 +115,7 @@
     "TempSpeed": {
       "Label": "Врем. скорость"
     },
+    "MinimalBonus": "минимальный бонус",
     "abilityAbbreviations": {
       "spi": "Дух",
       "con": "Тело",

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -3,7 +3,7 @@
  * @extends {ActorSheet}
  */
 
-import { getRankAndDie, getColorRank } from '../helpers/utils.mjs';
+import { getColorRank } from '../helpers/utils.mjs';
 
 export class myrpgActorSheet extends ActorSheet {
   /** @override */
@@ -551,21 +551,29 @@ export class myrpgActorSheet extends ActorSheet {
 
     let bonus = 0;
     let abVal = 0;
+    let minimal = false;
 
     if (skill) {
       bonus = parseInt(this.actor.system.skills[skill]?.value) || 0;
       const abKey = this.actor.system.skills[skill].ability;
       abVal = parseInt(this.actor.system.abilities[abKey]?.value) || 0;
+
+      const minBonus = Math.ceil(abVal / 2);
+      if (bonus < minBonus) {
+        bonus = minBonus;
+        minimal = true;
+      }
     } else if (ability) {
       abVal = parseInt(this.actor.system.abilities[ability]?.value) || 0;
       bonus = abVal; // ��� ������ ����� ��������������
     }
 
-    const { die } = getRankAndDie(abVal);
-    const roll = await new Roll(`2d${die} + ${bonus}`).roll({ async: true });
+    const roll = await new Roll(`1d10 + ${bonus}`).roll({ async: true });
+    let flavor = label;
+    if (minimal) flavor += `: ${game.i18n.localize('MY_RPG.MinimalBonus')}`;
     roll.toMessage({
       speaker: ChatMessage.getSpeaker({ actor: this.actor }),
-      flavor: label,
+      flavor,
       rollMode: game.settings.get('core', 'rollMode')
     });
   }

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.212",
+  "version": "2.213",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
## Summary
- roll d10 + ability/skill for all rolls
- use ability/2 as minimal bonus for skill rolls
- localize new minimal bonus note in EN and RU
- bump version to 2.213

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686a7fefc298832eb0800e199f310911