### PR TITLE
fix: remove unused ability die

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -3,7 +3,6 @@
  * @extends {Actor}
  */
 
-import { getRankAndDie } from '../helpers/utils.mjs';
 
 export class myrpgActor extends Actor {
   prepareDerivedData() {
@@ -17,7 +16,6 @@ export class myrpgActor extends Actor {
     /* 1. Способности ---------------------------------------------- */
     for (const a of Object.values(s.abilities)) {
       a.mod = a.value; // «бонус» = само значение
-      a.die = getRankAndDie(a.value).die; // размер куба 6/8/10/12/14
     }
 
     /* 2. Навыки ---------------------------------------------------- */

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -1,17 +1,6 @@
 // Utility functions for the myrpg system
 
 /**
- * Convert a numeric ability value to a rank and appropriate die size.
- * @param {number} [val=0] The ability value.
- * @returns {{rank: number, die: number}}
- */
-export function getRankAndDie(val = 0) {
-  const rank = Math.max(1, Math.floor((val - 1) / 4) + 1);
-  const die = [6, 8, 10, 12, 14][rank - 1] || 4;
-  return { rank, die };
-}
-
-/**
  * Determine a simplified rank (1-5) based on a value in steps of two.
  * Used purely for coloring cells in the UI.
  * @param {number} [val=0] The value to rank.

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.214",
+  "version": "2.215",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
## Summary
- drop obsolete `getRankAndDie` helper
- clean up `actor.mjs` and stop assigning `ability.die`
- bump version to 2.215

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a84f46548832ea14da97866eaa014