### PR TITLE
Fix biography header CSS duplication

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -645,13 +645,6 @@ form textarea {
   5) (      )                   (h2/h3)            
                                       
  *******************************************************/
-.tab.biography h2,
-.tab.biography h3,
-.tab.abilities h2,
-.tab.abilities h3 {
-  text-align: center;
-  font-weight: 700; /*              */
-}
 
 .limited-height {
   height: 280px;

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.222",
+  "version": "2.223",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
## Summary
- remove duplicate CSS rule for biography/abilities headings
- bump version to 2.223

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d31359e08832e96a9eda6878864b7