### PR TITLE
Implement world mode switch

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -15,6 +15,14 @@
       "Yes": "Yes",
       "No": "No"
     },
+    "WorldMode": {
+      "SettingName": "World Mode",
+      "SettingHint": "Select which world rules are used.",
+      "Unity": "Unity",
+      "Stellar": "Stellar",
+      "DialogTitle": "Select World Mode",
+      "DialogContent": "Choose the rule set for this campaign."
+    },
     "RankGradient": {
       "Title": "Rank Gradient",
       "Rank1": "Wood",
@@ -22,6 +30,13 @@
       "Rank3": "Silver",
       "Rank4": "Gold",
       "Rank5": "Sky"
+    },
+    "RankNumeric": {
+      "Rank1": "Rank 1",
+      "Rank2": "Rank 2",
+      "Rank3": "Rank 3",
+      "Rank4": "Rank 4",
+      "Rank5": "Rank 5"
     },
     "KeyInfo": {
       "Calling": "Calling",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -15,6 +15,14 @@
       "Yes": "Да",
       "No": "Нет"
     },
+    "WorldMode": {
+      "SettingName": "Мир",
+      "SettingHint": "Выберите набор правил для этой кампании.",
+      "Unity": "Юнити",
+      "Stellar": "Стеллар",
+      "DialogTitle": "Выбор мира",
+      "DialogContent": "Выберите мир, правила которого будут использоваться."
+    },
     "Defenses": {
       "PhysicalLabel": "Физическая защита",
       "MagicalLabel": "Магическая защита",
@@ -27,6 +35,13 @@
       "Rank3": "Серебро",
       "Rank4": "Золото",
       "Rank5": "Небо"
+    },
+    "RankNumeric": {
+      "Rank1": "Ранг 1",
+      "Rank2": "Ранг 2",
+      "Rank3": "Ранг 3",
+      "Rank4": "Ранг 4",
+      "Rank5": "Ранг 5"
     },
     "ArmorItem": {
       "ArmorSectionTitle": "Доспех",

--- a/module/helpers/handlebars-helpers.mjs
+++ b/module/helpers/handlebars-helpers.mjs
@@ -36,3 +36,10 @@ Handlebars.registerHelper('times', function (n, options) {
 Handlebars.registerHelper('lte', function (a, b, options) {
   return a <= b ? options.fn(this) : options.inverse(this);
 });
+
+// Return the rank label based on current world mode
+Handlebars.registerHelper('rankLabel', function (rankNum) {
+  const mode = game.settings.get('myrpg', 'worldType');
+  const base = mode === 'stellar' ? 'MY_RPG.RankNumeric' : 'MY_RPG.RankGradient';
+  return game.i18n.localize(`${base}.Rank${rankNum}`);
+});

--- a/module/myrpg.mjs
+++ b/module/myrpg.mjs
@@ -21,6 +21,26 @@ Hooks.once('init', function () {
   // Add custom constants for configuration.
   CONFIG.MY_RPG = MY_RPG;
 
+  game.settings.register('myrpg', 'worldType', {
+    name: 'MY_RPG.WorldMode.SettingName',
+    hint: 'MY_RPG.WorldMode.SettingHint',
+    scope: 'world',
+    config: true,
+    type: String,
+    choices: {
+      unity: game.i18n.localize('MY_RPG.WorldMode.Unity'),
+      stellar: game.i18n.localize('MY_RPG.WorldMode.Stellar')
+    },
+    default: 'unity'
+  });
+
+  game.settings.register('myrpg', 'worldTypeChosen', {
+    scope: 'world',
+    config: false,
+    type: Boolean,
+    default: false
+  });
+
   // Define custom Document classes
   CONFIG.Actor.documentClass = myrpgActor;
 
@@ -40,4 +60,32 @@ Hooks.once('init', function () {
 
   // Preload Handlebars templates.
   return preloadHandlebarsTemplates();
+});
+
+Hooks.once('ready', function () {
+  if (!game.user.isGM) return;
+  if (game.settings.get('myrpg', 'worldTypeChosen')) return;
+
+  const content = `<p>${game.i18n.localize('MY_RPG.WorldMode.DialogContent')}</p>`;
+  new Dialog({
+    title: game.i18n.localize('MY_RPG.WorldMode.DialogTitle'),
+    content,
+    buttons: {
+      unity: {
+        label: game.i18n.localize('MY_RPG.WorldMode.Unity'),
+        callback: () => {
+          game.settings.set('myrpg', 'worldType', 'unity');
+          game.settings.set('myrpg', 'worldTypeChosen', true);
+        }
+      },
+      stellar: {
+        label: game.i18n.localize('MY_RPG.WorldMode.Stellar'),
+        callback: () => {
+          game.settings.set('myrpg', 'worldType', 'stellar');
+          game.settings.set('myrpg', 'worldTypeChosen', true);
+        }
+      }
+    },
+    default: 'unity'
+  }).render(true);
 });

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.223",
+  "version": "2.224",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -126,11 +126,11 @@
     <th colspan='5'>{{localize 'MY_RPG.RankGradient.Title'}}</th>
   </tr>
   <tr>
-    <td class='rank1'>{{localize 'MY_RPG.RankGradient.Rank1'}}</td>
-    <td class='rank2'>{{localize 'MY_RPG.RankGradient.Rank2'}}</td>
-    <td class='rank3'>{{localize 'MY_RPG.RankGradient.Rank3'}}</td>
-    <td class='rank4'>{{localize 'MY_RPG.RankGradient.Rank4'}}</td>
-    <td class='rank5'>{{localize 'MY_RPG.RankGradient.Rank5'}}</td>
+    <td class='rank1'>{{rankLabel 1}}</td>
+    <td class='rank2'>{{rankLabel 2}}</td>
+    <td class='rank3'>{{rankLabel 3}}</td>
+    <td class='rank4'>{{rankLabel 4}}</td>
+    <td class='rank5'>{{rankLabel 5}}</td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Summary
- add world mode game setting with first-run dialog
- show rank gradient labels using new helper
- provide localisation for new UI strings
- bump version to 2.224

## Testing
- `npm exec eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e23bd7538832e908c481977a0ceab