### PR TITLE
Limit TinyMCE toolbar and unify style

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -564,45 +564,43 @@ form textarea {
 
 /*                             */
 .myrpg .tox-tinymce {
-  border: 2px solid #1b1210 !important;
-  background-color: #f8f8f8 !important;
-  border-radius: 4px !important;
+  border: 2px solid #1b1210;
+  background-color: #f8f8f8;
   box-sizing: border-box;
-  margin: 0 !important;
-  padding: 0 !important;
-  width: 100% !important; /*            ,                                  */
+  margin: 0;
+  padding: 0;
+  width: 100%; /*            ,                                  */
 }
 
 /*                 ,                               */
 .myrpg .tox-tinymce .tox-editor-container {
-  background-color: #f8f8f8 !important;
-  border: none !important;
-  min-height: 40px !important; /*                             40px */
+  background-color: #f8f8f8;
+  border: none;
+  min-height: 40px; /*                             40px */
   box-sizing: border-box;
 }
 
 /*     iframe,                                 */
 .myrpg .tox-tinymce .tox-edit-area__iframe {
-  background-color: #f8f8f8 !important;
+  background-color: #f8f8f8;
 }
 
 /*                ,                  .myrpg (              <input>   <textarea>) */
 .myrpg .tox-tinymce * {
-  font-family: inherit !important;
-  font-size: inherit !important;
-  color: #1b1210 !important;
+  font-family: inherit;
+  font-size: inherit;
+  color: #1b1210;
 }
 
 /* ---             --- */
 
 .window-app.dialog .tox-tinymce {
-  border: 2px solid #1b1210 !important;
-  background-color: #f8f8f8 !important;
-  border-radius: 4px !important;
+  border: 2px solid #1b1210;
+  background-color: #f8f8f8;
   box-sizing: border-box;
-  margin: 0 !important;
-  padding: 0 !important;
-  width: 100% !important;
+  margin: 0;
+  padding: 0;
+  width: 100%;
 }
 
 .window-app.dialog .form-group {

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -71,8 +71,8 @@ export class myrpgActorSheet extends ActorSheet {
         menubar: false,
         branding: false,
         statusbar: false,
-        plugins: 'autoresize link lists',
-        toolbar: false,
+        plugins: 'autoresize',
+        toolbar: 'bold italic strikethrough',
         content_style:
           'body, p { margin: 0; padding: 0; font-family: inherit; font-size: inherit; color: #1b1210; }',
         autoresize_min_height: 40,
@@ -390,8 +390,8 @@ export class myrpgActorSheet extends ActorSheet {
                 menubar: false,
                 branding: false,
                 statusbar: false,
-                plugins: 'autoresize link lists', // contextmenu �����
-                toolbar: false, // ����� ������ ��� ��������
+                plugins: 'autoresize', // contextmenu �����
+                toolbar: 'bold italic strikethrough', // ����� ������ ��� ��������
                 // ���� ��� ��-���� ����� �����-���� ����������� ����, ������������ � ������������� TinyMCE 6
                 content_style:
                   'body { margin: 0; padding: 0; font-family: inherit; font-size: inherit; color: #1b1210; }',

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.224",
+  "version": "2.225",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
## Summary
- remove `!important` and radius styles from TinyMCE boxes
- match fonts and colours with regular inputs
- only allow **bold**, *italic* and ~~strikethrough~~ in editors
- bump version to 2.225

## Testing
- `npm test` *(fails: no test specified)*
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e2a3bda8c832e9a2992aa72cf2059