### PR TITLE
feat: standardize key info inputs

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -28,6 +28,23 @@
   max-width: 150px;
 }
 
+/* unified appearance for key info inputs */
+.key-info-input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.key-info-grid .resource-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.key-info-input[readonly] {
+  background-color: #f8f8f8;
+  color: #1b1210;
+}
+
 .skill-row {
   display: flex;
   align-items: center;

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.226",
+  "version": "2.228",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -138,38 +138,69 @@
           </section>
 
 
-          <section class='resources grid grid-3col'>
-  <!-- Имя -->
-  <div class='resource flex-group-center'>
-    <label class='resource-label'>{{localize 'MY_RPG.KeyInfo.Name'}}</label>
-    <div class='resource-content flexrow flex-center'>
-      <input type='text' name='name' value='{{actor.name}}'/>
-    </div>
-  </div>
-
-  <!-- Призвание -->
-  <div class='resource flex-group-center'>
-    <label class='resource-label'>{{localize 'MY_RPG.KeyInfo.Calling'}}</label>
-    <div class='resource-content flexrow flex-center'>
-      <input type='text' name='system.calling' value='{{system.calling}}'/>
-    </div>
-  </div>
-
-  <!-- Текущий ранг -->
-  <div class='resource flex-group-center'>
-    <label class='resource-label'>{{localize 'MY_RPG.KeyInfo.CurrentRank'}}</label>
-    <div class='resource-content flexrow flex-center'>
-      <input type='text' name='system.currentRank' value='{{system.currentRank}}'/>
-    </div>
-  </div>
-
+          <section class='resources grid grid-2col key-info-grid'>
             <div class='resource flex-group-center'>
-              <label class='resource-label'>
-                {{localize 'MY_RPG.KeyInfo.MomentOfGlory'}}
-              </label>
+              <label class='resource-label'>{{localize 'MY_RPG.Health.SubCurrent'}}</label>
               <div class='resource-content flexcol'>
                 <input
                   type='number'
+                  class='key-info-input'
+                  name='system.health.value'
+                  value='{{system.health.value}}'
+                  step='1'
+                  inputmode='numeric'
+                />
+              </div>
+            </div>
+            <div class='resource flex-group-center'>
+              <label class='resource-label'>{{localize 'MY_RPG.Health.SubMax'}}</label>
+              <div class='resource-content flexcol'>
+                <input
+                  type='number'
+                  class='key-info-input'
+                  name='system.health.max'
+                  value='{{system.health.max}}'
+                  step='1'
+                  inputmode='numeric'
+                  readonly
+                  tabindex='-1'
+                />
+              </div>
+            </div>
+          </section>
+
+
+          <section class='resources grid grid-3col key-info-grid'>
+            <!-- Имя -->
+            <div class='resource flex-group-center'>
+              <label class='resource-label'>{{localize 'MY_RPG.KeyInfo.Name'}}</label>
+              <div class='resource-content flexcol'>
+                <input type='text' class='key-info-input' name='name' value='{{actor.name}}'/>
+              </div>
+            </div>
+
+            <!-- Призвание -->
+            <div class='resource flex-group-center'>
+              <label class='resource-label'>{{localize 'MY_RPG.KeyInfo.Calling'}}</label>
+              <div class='resource-content flexcol'>
+                <input type='text' class='key-info-input' name='system.calling' value='{{system.calling}}'/>
+              </div>
+            </div>
+
+            <!-- Текущий ранг -->
+            <div class='resource flex-group-center'>
+              <label class='resource-label'>{{localize 'MY_RPG.KeyInfo.CurrentRank'}}</label>
+              <div class='resource-content flexcol'>
+                <input type='text' class='key-info-input' name='system.currentRank' value='{{system.currentRank}}'/>
+              </div>
+            </div>
+
+            <div class='resource flex-group-center'>
+              <label class='resource-label'>{{localize 'MY_RPG.KeyInfo.MomentOfGlory'}}</label>
+              <div class='resource-content flexcol'>
+                <input
+                  type='number'
+                  class='key-info-input'
                   name='system.momentOfGlory'
                   value='{{system.momentOfGlory}}'
                   step='1'
@@ -178,39 +209,13 @@
               </div>
             </div>
             <!--    -->
-            <div class='resource flex-group-center'>
-              <label class='resource-label'>{{localize 'MY_RPG.Health.Label'}}</label>
-              <div class='resource-content flexcol'>
-                <div class='sub-labels flexrow flex-group-center'>
-                  <div class='sub-label'>{{localize 'MY_RPG.Health.SubCurrent'}}</div>
-                  <div class='sub-label'>{{localize 'MY_RPG.Health.SubMax'}}</div>
-                </div>
-                <div class='flexrow flex-group-center'>
-                  <input
-                    type='number'
-                    name='system.health.value'
-                    value='{{system.health.value}}'
-                    step='1'
-                    inputmode='numeric'
-                  />
-                  <input
-                    type='number'
-                    name='system.health.max'
-                    value='{{system.health.max}}'
-                    step='1'
-                    inputmode='numeric'
-                    readonly
-                    tabindex='-1'
-                  />
-                </div>
-              </div>
-            </div>
             <!--       (Flux) -->
             <div class='resource flex-group-center'>
               <label class='resource-label'>{{localize 'MY_RPG.Flux.Label'}}</label>
-              <div class='resource-content flexrow flex-center'>
+              <div class='resource-content flexcol'>
                 <input
                   type='number'
+                  class='key-info-input'
                   name='system.flux.value'
                   value='{{system.flux.value}}'
                   step='1'
@@ -223,9 +228,10 @@
             <!--          (Speed) -->
             <div class='resource flex-group-center'>
               <label class='resource-label'>{{localize 'MY_RPG.Speed.Label'}}</label>
-              <div class='resource-content flexrow flex-center'>
+              <div class='resource-content flexcol'>
                 <input
                   type='number'
+                  class='key-info-input'
                   name='system.speed.value'
                   value='{{system.speed.value}}'
                   step='1'
@@ -243,6 +249,7 @@
               <div class='resource-content flexcol'>
                 <input
                   type='number'
+                  class='key-info-input'
                   name='system.defenses.physical'
                   value='{{system.defenses.physical}}'
                   step='1'
@@ -260,6 +267,7 @@
               <div class='resource-content flexcol'>
                 <input
                   type='number'
+                  class='key-info-input'
                   name='system.defenses.azure'
                   value='{{system.defenses.azure}}'
                   step='1'
@@ -277,6 +285,7 @@
               <div class='resource-content flexcol'>
                 <input
                   type='number'
+                  class='key-info-input'
                   name='system.defenses.mental'
                   value='{{system.defenses.mental}}'
                   step='1'
@@ -398,9 +407,10 @@
             <label for='system.flux.value' class='resource-label'>
               {{localize 'MY_RPG.Flux.Label'}}
             </label>
-            <div class='resource-content flexrow flex-center'>
+            <div class='resource-content flexcol'>
               <input
                 type='number'
+                class='key-info-input'
                 name='system.flux.value'
                 value='{{system.flux.value}}'
                 step='1'


### PR DESCRIPTION
## Summary
- standardize layout for all key info fields
- add `.key-info-grid` CSS for consistent flex column style
- split health inputs into a dedicated two-column row
- bump version to 2.228

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e35855910832e89e2e123d74defa3