### PR TITLE
feat: restore health section heading

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -45,6 +45,12 @@
   color: #1b1210;
 }
 
+.key-info-divider {
+  border: 0;
+  border-top: 2px solid #1b1210;
+  margin: 4px 0;
+}
+
 .skill-row {
   display: flex;
   align-items: center;

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.228",
+  "version": "2.229",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -138,6 +138,7 @@
           </section>
 
 
+          <h4 class='key-info-health-heading'>{{localize 'MY_RPG.Health.Label'}}</h4>
           <section class='resources grid grid-2col key-info-grid'>
             <div class='resource flex-group-center'>
               <label class='resource-label'>{{localize 'MY_RPG.Health.SubCurrent'}}</label>
@@ -169,6 +170,7 @@
             </div>
           </section>
 
+          <hr class='key-info-divider' />
 
           <section class='resources grid grid-3col key-info-grid'>
             <!-- Имя -->


### PR DESCRIPTION
## Summary
- restore health heading in character sheet
- split health row from main stats with divider
- style divider and bump version

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 404 Not Found - prettier-plugin-handlebars)*

------
https://chatgpt.com/codex/tasks/task_e_686e3c02395c832ea2305745e2a30e27