### PR TITLE
fix: refine TinyMCE styles

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -578,12 +578,14 @@ form textarea {
 /* ---                                     TinyMCE (Foundry V10+),                         .tox-... --- */
 
 /*                             */
-.myrpg .tox-tinymce {
+.myrpg .tox-tinymce,
+.window-app.dialog .tox-tinymce {
   border: 2px solid #1b1210;
   background-color: #f8f8f8;
   box-sizing: border-box;
   margin: 0;
   padding: 0;
+  border-radius: 6px;
   width: 100%; /*            ,                                  */
 }
 
@@ -593,30 +595,26 @@ form textarea {
   border: none;
   min-height: 40px; /*                             40px */
   box-sizing: border-box;
+  text-align: center;
+  padding: 0;
 }
 
 /*     iframe,                                 */
 .myrpg .tox-tinymce .tox-edit-area__iframe {
   background-color: #f8f8f8;
+  padding: 0;
 }
 
 /*                ,                  .myrpg (              <input>   <textarea>) */
 .myrpg .tox-tinymce * {
   font-family: inherit;
   font-size: inherit;
+  line-height: inherit;
   color: #1b1210;
+  text-align: inherit;
 }
 
 /* ---             --- */
-
-.window-app.dialog .tox-tinymce {
-  border: 2px solid #1b1210;
-  background-color: #f8f8f8;
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-  width: 100%;
-}
 
 .window-app.dialog .form-group {
   display: flex;

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -71,16 +71,20 @@ export class myrpgActorSheet extends ActorSheet {
         menubar: false,
         branding: false,
         statusbar: false,
-        plugins: 'autoresize',
-        toolbar: 'bold italic strikethrough',
+        plugins: 'autoresize contextmenu paste',
+        toolbar: false,
+        contextmenu: 'bold italic strikethrough',
+        valid_elements: 'p,strong/b,em/i,strike/s,br',
         content_style:
-          'body, p { margin: 0; padding: 0; font-family: inherit; font-size: inherit; color: #1b1210; }',
+          'body { margin: 0; padding: 5px; font-family: inherit; font-size: inherit; color: #1b1210; text-align: center; } p { margin: 0; }',
         autoresize_min_height: 40,
         autoresize_bottom_margin: 0,
         width: '100%',
         setup: function (editor) {
-          editor.on('init', function () {
-            // �������������� ���������, ���� �����
+          editor.on('Paste', (e) => {
+            e.preventDefault();
+            const text = (e.clipboardData || window.clipboardData).getData('text/plain');
+            editor.insertContent(text.replace(/\n/g, '<br>'));
           });
         }
       });
@@ -382,31 +386,9 @@ export class myrpgActorSheet extends ActorSheet {
           this._editing = false;
         },
         render: (html) => {
-          html.find('textarea.rich-editor').each(function () {
-            if (!this._tinyMCEInitialized) {
-              tinymce.init({
-                target: this,
-                inline: false,
-                menubar: false,
-                branding: false,
-                statusbar: false,
-                plugins: 'autoresize', // contextmenu �����
-                toolbar: 'bold italic strikethrough', // ����� ������ ��� ��������
-                // ���� ��� ��-���� ����� �����-���� ����������� ����, ������������ � ������������� TinyMCE 6
-                content_style:
-                  'body { margin: 0; padding: 0; font-family: inherit; font-size: inherit; color: #1b1210; }',
-                autoresize_min_height: 40,
-                autoresize_bottom_margin: 0,
-                width: '100%',
-                setup: function (editor) {
-                  editor.on('init', function () {
-                    // �������������� ���������, ���� �����
-                  });
-                }
-              });
-              this._tinyMCEInitialized = true;
-            }
-          });
+          html
+            .find('textarea.rich-editor')
+            .each((i, el) => this.initializeRichEditor(el));
         }
       });
       diag.render(true);

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.230",
+  "version": "2.232",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
## Summary
- ensure TinyMCE widgets inherit textarea styles
- simplify TinyMCE dialog initialisation
- bump version to 2.232

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e4f68b580832ea6a2b371db67e7c3