### PR TITLE
Restrict TinyMCE usage

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -597,7 +597,6 @@ form textarea {
   border: none;
   min-height: 60px;
   box-sizing: border-box;
-  text-align: center;
   padding: 0;
 }
 
@@ -613,7 +612,6 @@ form textarea {
   font-size: inherit;
   line-height: inherit;
   color: #1b1210;
-  text-align: inherit;
 }
 
 /* ---             --- */

--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -582,18 +582,20 @@ form textarea {
 .window-app.dialog .tox-tinymce {
   border: 2px solid #1b1210;
   background-color: #f8f8f8;
+  color: #1b1210;
+  font-family: inherit;
+  font-size: inherit;
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  border-radius: 6px;
-  width: 100%; /*            ,                                  */
+  width: 100%;
 }
 
 /*                 ,                               */
 .myrpg .tox-tinymce .tox-editor-container {
   background-color: #f8f8f8;
   border: none;
-  min-height: 40px; /*                             40px */
+  min-height: 60px;
   box-sizing: border-box;
   text-align: center;
   padding: 0;

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -8,36 +8,21 @@ import { getColorRank } from '../helpers/utils.mjs';
 export class myrpgActorSheet extends ActorSheet {
   /** @override */
   async _render(force = false, options = {}) {
-    // ��������� ������� ��������� �������
     const scrollContainer = this.element.find('.sheet-scrollable');
     const scrollPos = scrollContainer.scrollTop();
-
-    // �������� ������������ ���������� �������
     await super._render(force, options);
 
-    // ��������������� ��������� �������
     this.element.find('.sheet-scrollable').scrollTop(scrollPos);
   }
 
   async close(options = {}) {
-    // ������� ��� ���������� tooltip
     $('body').find('.ability-tooltip').remove();
     return super.close(options);
   }
 
-  /**
-   * ���������� �������� ���� � �����, ��������� � ���������������� � ��������.
-   * ��� ��������� ��������� � �������������� ������� �����������.
-   * @param {HTMLElement} input - DOM-������� input, ������� �������� ��������.
-   * @returns {number} - ����������� �������� ��������.
-   */
   validateNumericInput(input) {
     let val = parseInt(input.value, 10);
     const isAbility = input.name.includes('system.abilities.');
-    // ���������� ����������� ��� �������� ���� ����:
-    // �������� � ����������� ��������� �����:
-    // "MY_RPG.NumericWarning.Attribute": "��������������" (ru) / "Attribute" (en)
-    // "MY_RPG.NumericWarning.Skill": "�����" (ru) / "Skill" (en)
     const labelKey = isAbility ? 'MY_RPG.NumericWarning.Attribute' : 'MY_RPG.NumericWarning.Skill';
     const label = game.i18n.localize(labelKey);
     const minVal = 0;
@@ -45,7 +30,6 @@ export class myrpgActorSheet extends ActorSheet {
     if (isNaN(val)) {
       val = minVal;
     }
-    // ��� ���������� ������������ �������� � ������� ����������� � �������������� �������
     if (val < minVal) {
       ui.notifications.warn(
         game.i18n.format('MY_RPG.NumericWarning.Min', {
@@ -59,10 +43,6 @@ export class myrpgActorSheet extends ActorSheet {
     return val;
   }
 
-  /**
-   * �������������� TinyMCE ��� ��������� ��������, ���� �� ��� �� ���������������.
-   * @param {HTMLElement} element - DOM-������� textarea, ��� �������� ��������� TinyMCE.
-   */
   initializeRichEditor(element) {
     if (!element._tinyMCEInitialized) {
       tinymce.init({
@@ -76,7 +56,7 @@ export class myrpgActorSheet extends ActorSheet {
         contextmenu: 'bold italic strikethrough',
         valid_elements: 'p,strong/b,em/i,strike/s,br',
         content_style:
-          'body { margin: 0; padding: 5px; font-family: inherit; font-size: inherit; color: #1b1210; text-align: center; } p { margin: 0; }',
+          'body { margin: 0; padding: 5px; font-family: inherit; font-size: inherit; color: #1b1210; } p { margin: 0; }',
         autoresize_min_height: 40,
         autoresize_bottom_margin: 0,
         width: '100%',

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -142,6 +142,9 @@ export class myrpgActorSheet extends ActorSheet {
 
   activateListeners(html) {
     super.activateListeners(html);
+    html
+      .find('textarea.rich-editor')
+      .each((i, el) => this.initializeRichEditor(el));
     html.find('.wound-box').click(this._onToggleWound.bind(this));
 
     // ----------------------------------------------------------------------

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.232",
+  "version": "2.233",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -68,13 +68,14 @@
           <div class='form-group'>
             <label>{{localize 'MY_RPG.Biography.Appearance'}}</label>
             <textarea
+              class='rich-editor'
               name='system.biography.appearance'
               rows='5'
             >{{system.biography.appearance}}</textarea>
           </div>
           <div class='form-group'>
             <label>{{localize 'MY_RPG.Biography.Notes'}}</label>
-            <textarea name='system.biography.notes' rows='8'>{{system.biography.notes}}</textarea>
+            <textarea class='rich-editor' name='system.biography.notes' rows='8'>{{system.biography.notes}}</textarea>
           </div>
         </section>
       </div>
@@ -463,7 +464,7 @@
           <h2>{{localize 'MY_RPG.ArmorItem.ArmorSectionTitle'}}</h2>
           <div class='armor-description'>
             <label>{{localize 'MY_RPG.ArmorItem.DescriptionLabel'}}</label>
-            <textarea name='system.armor.itemDesc' rows='3'>{{system.armor.itemDesc}}</textarea>
+            <textarea class='rich-editor' name='system.armor.itemDesc' rows='3'>{{system.armor.itemDesc}}</textarea>
           </div>
           <div class='armor-values flexrow'>
             <div class='flexcol'>

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -96,16 +96,7 @@
 
     {{! Biography Tab }}
     <div class='tab biography' data-group='primary' data-tab='description'>
-      {{! If you want TinyMCE editors to output inline rolls when rendered, you need to pass the actor's roll data to the rollData property. }}
-      {{editor
-        system.biography
-        target='system.biography'
-        rollData=rollData
-        button=true
-        owner=owner
-        editable=editable
-      }}
+      <textarea name='system.biography' rows='10'>{{system.biography}}</textarea>
     </div>
 
-  </section>
-</form>
+  </section></form>


### PR DESCRIPTION
## Summary
- use TinyMCE only for appearance, notes and armor description
- initialize rich text editors on sheet render
- remove TinyMCE from NPC biography
- style TinyMCE areas like normal text fields
- bump version to 2.233

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e59efe68c832e9aee846010708828