### PR TITLE
fix: clean ability effect borders

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -297,16 +297,14 @@ form textarea {
   transition: background-color 0.2s;
 }
 
-.abilities-table tr.ability-row .col-effect {
+.abilities-table tr.ability-row .col-effect .effect-wrapper {
   overflow: hidden;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
   max-height: 3em;
+  white-space: pre-wrap;
 }
 
-.abilities-table tr.ability-row.expanded .col-effect {
+.abilities-table tr.ability-row.expanded .col-effect .effect-wrapper {
   max-height: none;
-  display: block;
 }
 
 .tab.abilities table.abilities-table {

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.237",
+  "version": "2.239",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -439,7 +439,9 @@
                 <tr class='ability-row' data-index='{{i}}'>
                   <td class='col-name'>{{{row.name}}}</td>
                   <td class='col-rank'>{{row.rank}}</td>
-                  <td class='col-effect'>{{{row.effect}}}</td>
+                  <td class='col-effect'>
+                    <div class='effect-wrapper'>{{{row.effect}}}</div>
+                  </td>
                   <td class='col-cost'>{{row.cost}}</td>
                   <td class='col-delete'>
                     <a class='abilities-edit-row' data-index='{{i}}'>


### PR DESCRIPTION
## Summary
- remove `-webkit-box` display from ability effects
- keep cell borders intact during expand/collapse
- bump version to 2.239

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_686ebd6df858832eaa705372c3088289