### PR TITLE
feat: add inventory row editing

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -307,6 +307,16 @@ form textarea {
   max-height: none;
 }
 
+.abilities-table tr.inventory-row .col-effect .effect-wrapper {
+  overflow: hidden;
+  max-height: 3em;
+  white-space: pre-wrap;
+}
+
+.abilities-table tr.inventory-row.expanded .col-effect .effect-wrapper {
+  max-height: none;
+}
+
 .tab.abilities table.abilities-table {
   table-layout: fixed;
   width: 100%;
@@ -334,7 +344,7 @@ form textarea {
 
 .abilities-table td.col-delete a {
   display: inline-block;
-  margin: 0 2px;
+  margin: 0 6px;
   white-space: nowrap;
 }
 
@@ -357,7 +367,7 @@ form textarea {
 }
 
 .tab.inventory table.abilities-table th.col-delete {
-  width: 5%;
+  width: 9%;
 }
 
 /*                                                   */

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -238,12 +238,16 @@ export class myrpgActorSheet extends ActorSheet {
     });
 
     html.find('tr.inventory-row').click((ev) => {
-      if ($(ev.target).closest('.inventory-remove-row').length) return;
+      if ($(ev.target).closest('.inventory-remove-row, .inventory-edit-row').length) return;
+      $(ev.currentTarget).toggleClass('expanded');
+    });
+
+    html.find('.inventory-edit-row').click((ev) => {
+      ev.preventDefault();
       if (this._editing) {
         ui.notifications.warn(game.i18n.localize('MY_RPG.Inventory.AlreadyEditing'));
         return;
       }
-      ev.preventDefault();
       this._editing = true;
 
       const index = Number(ev.currentTarget.dataset.index);

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.239",
+  "version": "2.240",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -539,9 +539,14 @@
               {{#each system.inventoryList as |item i|}}
                 <tr class='inventory-row' data-index='{{i}}'>
                   <td class='col-name'>{{{item.name}}}</td>
-                  <td class='col-effect'>{{{item.desc}}}</td>
+                  <td class='col-effect'>
+                    <div class='effect-wrapper'>{{{item.desc}}}</div>
+                  </td>
                   <td class='col-cost'>{{item.quantity}}</td>
                   <td class='col-delete'>
+                    <a class='inventory-edit-row' data-index='{{i}}'>
+                      <i class='fa-solid fa-pen'></i>
+                    </a>
                     <a class='inventory-remove-row' data-index='{{i}}'>
                       <i class='fa-solid fa-trash'></i>
                     </a>


### PR DESCRIPTION
## Summary
- enable edit icons in inventory table
- style inventory table like abilities table
- widen delete/edit column to 9% and add spacing between icons
- bump version to 2.240

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686ec10eff98832e81231ec55f3e1c03