### PR TITLE
fix: save dialog edits immediately

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -200,9 +200,27 @@ export class myrpgActorSheet extends ActorSheet {
           this._editDialog = null;
         },
         render: (html) => {
-          html.find('textarea.rich-editor').each((index, element) => {
-            // �������� ����� ����� ������������� ���������
+          html.find('textarea.rich-editor').each((i, element) => {
+            // ensure TinyMCE editors are created
             this.initializeRichEditor(element);
+          });
+
+          const form = html.find('form');
+          form.on('input', 'input, textarea', () => {
+            tinymce.triggerSave();
+            const formEl = form[0];
+            const fd = new FormData(formEl);
+            let formData = {};
+            for (let [k, v] of fd.entries()) {
+              formData[k] = v;
+            }
+            abilities[index] = {
+              name: formData.name ?? '',
+              rank: formData.rank ?? '',
+              effect: formData.effect ?? '',
+              cost: formData.cost ?? ''
+            };
+            this.actor.update({ 'system.abilitiesList': abilities });
           });
         }
       });
@@ -280,6 +298,23 @@ export class myrpgActorSheet extends ActorSheet {
           html
             .find('textarea.rich-editor')
             .each((i, el) => this.initializeRichEditor(el));
+
+          const form = html.find('form');
+          form.on('input', 'input, textarea', () => {
+            tinymce.triggerSave();
+            const formEl = form[0];
+            const fd = new FormData(formEl);
+            let formData = {};
+            for (let [k, v] of fd.entries()) {
+              formData[k] = v;
+            }
+            inventory[index] = {
+              name: formData.name ?? '',
+              desc: formData.desc ?? '',
+              quantity: formData.quantity ?? ''
+            };
+            this.actor.update({ 'system.inventoryList': inventory });
+          });
         }
       });
       diag.render(true);

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.241",
+  "version": "2.243",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
## Summary
- save ability/inventory edits as soon as fields change
- bump version to 2.243

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686ec794ce44832ea6e50437cb0ebeaf