### PR TITLE
Implement mods table and biography update

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -555,6 +555,15 @@ form textarea {
   resize: vertical;
 }
 
+/* armor bonuses layout */
+.armor-values {
+  gap: 8px;
+  margin-top: 8px;
+}
+.armor-values .flexcol input {
+  width: 80%;
+}
+
 /*                                             */
 .myrpg.sheet.actor form input[type='text'],
 .myrpg.sheet.actor form input[type='number'],

--- a/lang/en.json
+++ b/lang/en.json
@@ -187,10 +187,19 @@
       "EyeColor": "Eye Color",
       "HairColor": "Hair Color",
       "Appearance": "Appearance",
+      "Story": "Biography",
       "Notes": "Notes"
     },
     "AbilitiesTable": {
-      "TableHeading": "Abilities Table",
+      "TableHeading": "Abilities",
+      "Name": "Name",
+      "Effect": "Effect",
+      "Cost": "Cost",
+      "AddRow": "Add Row",
+      "Rank": "Rank"
+    },
+    "ModsTable": {
+      "TableHeading": "Skills and Mods",
       "Name": "Name",
       "Effect": "Effect",
       "Cost": "Cost",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -187,10 +187,19 @@
       "EyeColor": "Цвет глаз",
       "HairColor": "Цвет волос",
       "Appearance": "Внешность",
+      "Story": "Биография",
       "Notes": "Заметки"
     },
     "AbilitiesTable": {
-      "TableHeading": "Таблица способностей",
+      "TableHeading": "Способности",
+      "Name": "Название",
+      "Effect": "Эффект",
+      "Cost": "Стоимость",
+      "AddRow": "Добавить строку",
+      "Rank": "Ранг"
+    },
+    "ModsTable": {
+      "TableHeading": "Умения и модификации",
       "Name": "Название",
       "Effect": "Эффект",
       "Cost": "Стоимость",

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.245",
+  "version": "2.246",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/template.json
+++ b/template.json
@@ -20,6 +20,7 @@
           }
         },
         "abilitiesList": [],
+        "modsList": [],
         "inventoryList": [],
         "health": {
           "value": 20,
@@ -168,6 +169,7 @@
         "eyeColor": "",
         "hairColor": "",
         "appearance": "",
+        "story": "",
         "notes": ""
       },
       "attributes": {}

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -74,6 +74,10 @@
             >{{system.biography.appearance}}</textarea>
           </div>
           <div class='form-group'>
+            <label>{{localize 'MY_RPG.Biography.Story'}}</label>
+            <textarea class='rich-editor' name='system.biography.story' rows='6'>{{system.biography.story}}</textarea>
+          </div>
+          <div class='form-group'>
             <label>{{localize 'MY_RPG.Biography.Notes'}}</label>
             <textarea class='rich-editor' name='system.biography.notes' rows='8'>{{system.biography.notes}}</textarea>
           </div>
@@ -403,7 +407,6 @@
 
       <div class='tab abilities' data-group='primary' data-tab='abilities'>
         <section class='flux-section'>
-          <h1>{{localize 'MY_RPG.SheetLabels.Abilities'}}</h1>
           <div class='resource flex-group-center'>
             <label for='system.flux.value' class='resource-label'>
               {{localize 'MY_RPG.Flux.Label'}}
@@ -457,6 +460,46 @@
                 <td colspan='5'>
                   <i class='fa-solid fa-plus'></i>
                   {{localize 'MY_RPG.AbilitiesTable.AddRow'}}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+        <section class='mods-section'>
+          <h2>{{localize 'MY_RPG.ModsTable.TableHeading'}}</h2>
+          <table class='abilities-table mods-table'>
+            <thead>
+              <tr>
+                <th class='col-name'>{{localize 'MY_RPG.ModsTable.Name'}}</th>
+                <th class='col-rank'>{{localize 'MY_RPG.ModsTable.Rank'}}</th>
+                <th class='col-effect'>{{localize 'MY_RPG.ModsTable.Effect'}}</th>
+                <th class='col-cost'>{{localize 'MY_RPG.ModsTable.Cost'}}</th>
+                <th class='col-delete'></th>
+              </tr>
+            </thead>
+            <tbody>
+              {{#each system.modsList as |row i|}}
+                <tr class='mod-row' data-index='{{i}}'>
+                  <td class='col-name'>{{{row.name}}}</td>
+                  <td class='col-rank'>{{row.rank}}</td>
+                  <td class='col-effect'>
+                    <div class='effect-wrapper'>{{{row.effect}}}</div>
+                  </td>
+                  <td class='col-cost'>{{row.cost}}</td>
+                  <td class='col-delete'>
+                    <a class='mods-edit-row' data-index='{{i}}'>
+                      <i class='fa-solid fa-pen'></i>
+                    </a>
+                    <a class='mods-remove-row' data-index='{{i}}'>
+                      <i class='fa-solid fa-trash'></i>
+                    </a>
+                  </td>
+                </tr>
+              {{/each}}
+              <tr class='add-row'>
+                <td colspan='5'>
+                  <i class='fa-solid fa-plus'></i>
+                  {{localize 'MY_RPG.ModsTable.AddRow'}}
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
## Summary
- add biography story field and mods table
- update translations for biography story and skills/mods table
- adjust armor input layout
- handle mods table in actor sheet logic
- bump version to 2.246

## Testing
- `npm exec eslint -- .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6870161941f8832e9b155eeefaa6f3f6