### PR TITLE
Improve mods table display

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -288,7 +288,7 @@ form textarea {
 }
 
 .myrpg .abilities-table tr:nth-child(even) {
-  background-color: #a79086 !important;
+  background-color: #c1b1aa !important;
 }
 
 .myrpg .abilities-table tr:hover td {
@@ -304,6 +304,16 @@ form textarea {
 }
 
 .abilities-table tr.ability-row.expanded .col-effect .effect-wrapper {
+  max-height: none;
+}
+
+.abilities-table tr.mod-row .col-effect .effect-wrapper {
+  overflow: hidden;
+  max-height: 3em;
+  white-space: pre-wrap;
+}
+
+.abilities-table tr.mod-row.expanded .col-effect .effect-wrapper {
   max-height: none;
 }
 
@@ -340,6 +350,10 @@ form textarea {
 
 .tab.abilities table.abilities-table th.col-delete {
   width: 9% !important;
+}
+
+.mods-section {
+  margin-top: 50px;
 }
 
 .abilities-table td.col-delete a {

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.246",
+  "version": "2.247",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
## Summary
- style dark rows lighter
- collapse/expand mod rows like abilities table
- add spacing before mods section
- bump version to 2.247

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 404 Not Found for prettier-plugin-handlebars)*

------
https://chatgpt.com/codex/tasks/task_e_68701cdfab1c832ebb3b97baa79ed219