### PR TITLE
fix: correct row handling for mods and inventory

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -112,7 +112,7 @@ export class myrpgActorSheet extends ActorSheet {
     });
 
     // �������� ����� ����������� (������)
-    html.find('tr.add-row').click((ev) => {
+    html.find('.abilities-section tr.add-row').click((ev) => {
       ev.preventDefault();
       let abilities = foundry.utils.deepClone(this.actor.system.abilitiesList) || [];
       if (!Array.isArray(abilities)) abilities = Object.values(abilities);
@@ -253,7 +253,7 @@ export class myrpgActorSheet extends ActorSheet {
     // ----------------------------------------------------------------------
     // Mods table actions
     // ----------------------------------------------------------------------
-    html.find('tr.mod-row').click((ev) => {
+    html.find('.mods-section tr.mod-row').click((ev) => {
       if ($(ev.target).closest('.mods-remove-row, .mods-edit-row').length) return;
       $(ev.currentTarget).toggleClass('expanded');
     });
@@ -397,7 +397,7 @@ export class myrpgActorSheet extends ActorSheet {
       this.actor.update({ 'system.inventoryList': inventory });
     });
 
-    html.find('tr.inventory-row').click((ev) => {
+    html.find('.inventory tr.inventory-row').click((ev) => {
       if ($(ev.target).closest('.inventory-remove-row, .inventory-edit-row').length) return;
       $(ev.currentTarget).toggleClass('expanded');
     });

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.247",
+  "version": "2.248",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
## Summary
- fix row creation event binding to only affect abilities table
- ensure consistent collapse/expand logic for mods and inventory
- bump version to 2.248

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6870208131fc832e81565ac1c6ce0a2f