### PR TITLE
Add inline quantity controls for inventory items

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -367,6 +367,17 @@ form textarea {
   white-space: nowrap;
 }
 
+.abilities-table td.col-cost {
+  white-space: nowrap;
+  text-align: center;
+}
+
+.abilities-table td.col-cost a {
+  display: inline-block;
+  margin: 0 4px;
+  white-space: nowrap;
+}
+
 /* CSS                                                             */
 .tab.inventory table.abilities-table {
   width: 100%;

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -481,7 +481,9 @@ export class myrpgActorSheet extends ActorSheet {
             row
               .find('.col-effect .effect-wrapper')
               .html(formData.desc ?? '');
-            row.find('.col-cost').text(formData.quantity ?? '');
+            row
+              .find('.col-cost .quantity-value')
+              .text(formData.quantity ?? '');
           });
         }
       });
@@ -512,6 +514,34 @@ export class myrpgActorSheet extends ActorSheet {
         },
         default: 'no'
       }).render(true);
+    });
+
+    html.find('.inventory-quantity-plus').click((ev) => {
+      ev.preventDefault();
+      const index = Number(ev.currentTarget.dataset.index);
+      let inventory = foundry.utils.deepClone(this.actor.system.inventoryList) || [];
+      if (!Array.isArray(inventory)) inventory = Object.values(inventory);
+      const current = parseInt(inventory[index]?.quantity) || 0;
+      inventory[index].quantity = current + 1;
+      this.actor.update({ 'system.inventoryList': inventory }, { render: false });
+      const row = this.element.find(
+        `.abilities-table tr.inventory-row[data-index="${index}"]`
+      );
+      row.find('.col-cost .quantity-value').text(inventory[index].quantity);
+    });
+
+    html.find('.inventory-quantity-minus').click((ev) => {
+      ev.preventDefault();
+      const index = Number(ev.currentTarget.dataset.index);
+      let inventory = foundry.utils.deepClone(this.actor.system.inventoryList) || [];
+      if (!Array.isArray(inventory)) inventory = Object.values(inventory);
+      const current = parseInt(inventory[index]?.quantity) || 0;
+      inventory[index].quantity = Math.max(0, current - 1);
+      this.actor.update({ 'system.inventoryList': inventory }, { render: false });
+      const row = this.element.find(
+        `.abilities-table tr.inventory-row[data-index="${index}"]`
+      );
+      row.find('.col-cost .quantity-value').text(inventory[index].quantity);
     });
 
     html

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.250",
+  "version": "2.251",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -582,7 +582,15 @@
                   <td class='col-effect'>
                     <div class='effect-wrapper'>{{{item.desc}}}</div>
                   </td>
-                  <td class='col-cost'>{{item.quantity}}</td>
+                  <td class='col-cost'>
+                    <a class='inventory-quantity-minus' data-index='{{i}}'>
+                      <i class='fa-solid fa-minus'></i>
+                    </a>
+                    <span class='quantity-value'>{{item.quantity}}</span>
+                    <a class='inventory-quantity-plus' data-index='{{i}}'>
+                      <i class='fa-solid fa-plus'></i>
+                    </a>
+                  </td>
                   <td class='col-delete'>
                     <a class='inventory-edit-row' data-index='{{i}}'>
                       <i class='fa-solid fa-pen'></i>


### PR DESCRIPTION
## Summary
- add +- controls in inventory quantity column
- handle quantity increment/decrement in sheet script
- style quantity cell icons
- bump version to 2.251

## Testing
- `npx eslint "**/*.mjs"` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6870bd3c8064832ebf4510486e27369f