### PR TITLE
feat: move add row buttons to table headers

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -112,7 +112,7 @@ export class myrpgActorSheet extends ActorSheet {
     });
 
     // �������� ����� ����������� (������)
-    html.find('.abilities-section tr.add-row').click((ev) => {
+    html.find('.abilities-section .abilities-add-row').click((ev) => {
       ev.preventDefault();
       let abilities = foundry.utils.deepClone(this.actor.system.abilitiesList) || [];
       if (!Array.isArray(abilities)) abilities = Object.values(abilities);
@@ -258,7 +258,7 @@ export class myrpgActorSheet extends ActorSheet {
       $(ev.currentTarget).toggleClass('expanded');
     });
 
-    html.find('.mods-table .add-row').click((ev) => {
+    html.find('.mods-add-row').click((ev) => {
       ev.preventDefault();
       let mods = foundry.utils.deepClone(this.actor.system.modsList) || [];
       if (!Array.isArray(mods)) mods = Object.values(mods);
@@ -385,7 +385,7 @@ export class myrpgActorSheet extends ActorSheet {
     // ----------------------------------------------------------------------
     // ������� ���������
     // ----------------------------------------------------------------------
-    html.find('.inventory .add-row').click((ev) => {
+    html.find('.inventory-add-row').click((ev) => {
       ev.preventDefault();
       let inventory = foundry.utils.deepClone(this.actor.system.inventoryList) || [];
       if (!Array.isArray(inventory)) inventory = Object.values(inventory);

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.251",
+  "version": "2.252",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -433,7 +433,11 @@
                 <th class='col-rank'>{{localize 'MY_RPG.AbilitiesTable.Rank'}}</th>
                 <th class='col-effect'>{{localize 'MY_RPG.AbilitiesTable.Effect'}}</th>
                 <th class='col-cost'>{{localize 'MY_RPG.AbilitiesTable.Cost'}}</th>
-                <th class='col-delete'></th>
+                <th class='col-delete'>
+                  <a class='abilities-add-row' title='{{localize "MY_RPG.AbilitiesTable.AddRow"}}'>
+                    <i class='fa-solid fa-plus'></i>
+                  </a>
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -455,12 +459,6 @@
                   </td>
                 </tr>
               {{/each}}
-              <tr class='add-row'>
-                <td colspan='5'>
-                  <i class='fa-solid fa-plus'></i>
-                  {{localize 'MY_RPG.AbilitiesTable.AddRow'}}
-                </td>
-              </tr>
             </tbody>
           </table>
         </section>
@@ -472,7 +470,11 @@
                 <th class='col-rank'>{{localize 'MY_RPG.ModsTable.Rank'}}</th>
                 <th class='col-effect'>{{localize 'MY_RPG.ModsTable.Effect'}}</th>
                 <th class='col-cost'>{{localize 'MY_RPG.ModsTable.Cost'}}</th>
-                <th class='col-delete'></th>
+                <th class='col-delete'>
+                  <a class='mods-add-row' title='{{localize "MY_RPG.ModsTable.AddRow"}}'>
+                    <i class='fa-solid fa-plus'></i>
+                  </a>
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -494,12 +496,6 @@
                   </td>
                 </tr>
               {{/each}}
-              <tr class='add-row'>
-                <td colspan='5'>
-                  <i class='fa-solid fa-plus'></i>
-                  {{localize 'MY_RPG.ModsTable.AddRow'}}
-                </td>
-              </tr>
             </tbody>
           </table>
         </section>
@@ -572,7 +568,11 @@
                 <th class='col-name primary-header'>{{localize 'MY_RPG.Inventory.EquipmentHeader'}}</th>
                 <th class='col-effect'>{{localize 'MY_RPG.Inventory.Description'}}</th>
                 <th class='col-cost'>{{localize 'MY_RPG.Inventory.Quantity'}}</th>
-                <th class='col-delete'></th>
+                <th class='col-delete'>
+                  <a class='inventory-add-row' title='{{localize "MY_RPG.Inventory.AddRow"}}'>
+                    <i class='fa-solid fa-plus'></i>
+                  </a>
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -601,12 +601,6 @@
                   </td>
                 </tr>
               {{/each}}
-              <tr class='add-row'>
-                <td colspan='4'>
-                  <i class='fa-solid fa-plus'></i>
-                  {{localize 'MY_RPG.Inventory.AddRow'}}
-                </td>
-              </tr>
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary
- place '+' buttons in table headers instead of separate rows
- update click handlers for new buttons
- bump version to 2.252

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6870c15aba40832e88c926c07ec2422d