### PR TITLE
feat: simplify table layout

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -142,19 +142,15 @@ textarea[disabled] {
 
 /*                                          */
 .myrpg .abilities-table th.col-name {
-  width: 30%;
-}
-
-.myrpg .abilities-table th.col-effect {
-  width: 55%;
+  width: 70%;
 }
 
 .myrpg .abilities-table th.col-cost {
-  width: 10%;
+  width: 20%;
 }
 
 .myrpg .abilities-table th.col-delete {
-  width: 5%;
+  width: 10%;
 }
 
 /*                        :
@@ -292,44 +288,25 @@ form textarea {
   font-weight: bold;
 }
 
-.myrpg .abilities-table tr:nth-child(even) {
+.myrpg .abilities-table tr:nth-child(even):not(.ability-effect-row):not(.mod-effect-row):not(.inventory-effect-row) {
   background-color: #c1b1aa !important;
 }
 
-.myrpg .abilities-table tr:hover td {
-  background-color: #673e37 !important; 
-  color: #d2d2c9 !important;
-  transition: background-color 0.2s;
-}
 
-.abilities-table tr.ability-row .col-effect .effect-wrapper {
-  overflow: hidden;
-  max-height: 3em;
+.abilities-table .effect-wrapper {
   white-space: pre-wrap;
 }
 
-.abilities-table tr.ability-row.expanded .col-effect .effect-wrapper {
-  max-height: none;
+.abilities-table .ability-effect-row,
+.abilities-table .mod-effect-row,
+.abilities-table .inventory-effect-row {
+  display: none;
 }
 
-.abilities-table tr.mod-row .col-effect .effect-wrapper {
-  overflow: hidden;
-  max-height: 3em;
-  white-space: pre-wrap;
-}
-
-.abilities-table tr.mod-row.expanded .col-effect .effect-wrapper {
-  max-height: none;
-}
-
-.abilities-table tr.inventory-row .col-effect .effect-wrapper {
-  overflow: hidden;
-  max-height: 3em;
-  white-space: pre-wrap;
-}
-
-.abilities-table tr.inventory-row.expanded .col-effect .effect-wrapper {
-  max-height: none;
+.abilities-table tr.expanded + .ability-effect-row,
+.abilities-table tr.expanded + .mod-effect-row,
+.abilities-table tr.expanded + .inventory-effect-row {
+  display: table-row;
 }
 
 .tab.abilities table.abilities-table {
@@ -338,15 +315,11 @@ form textarea {
 }
 
 .tab.abilities table.abilities-table th.col-name {
-  width: 25% !important;
+  width: 70% !important;
 }
 
 .tab.abilities table.abilities-table th.col-rank {
   width: 10% !important;
-}
-
-.tab.abilities table.abilities-table th.col-effect {
-  width: 45% !important;
 }
 
 .tab.abilities table.abilities-table th.col-cost {
@@ -385,15 +358,11 @@ form textarea {
 }
 
 .tab.inventory table.abilities-table th.col-name {
-  width: 25%;
-}
-
-.tab.inventory table.abilities-table th.col-effect {
-  width: 50%;
+  width: 70%;
 }
 
 .tab.inventory table.abilities-table th.col-cost {
-  width: 20%;
+  width: 21%;
 }
 
 .tab.inventory table.abilities-table th.col-delete {

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -100,9 +100,12 @@ export class myrpgActorSheet extends ActorSheet {
     const $table = html.find('.abilities-table');
 
     // toggle expanded ability description
-    html.find('tr.ability-row').click((ev) => {
-      if ($(ev.target).closest('.abilities-remove-row, .abilities-edit-row').length) return;
-      $(ev.currentTarget).toggleClass('expanded');
+    html.find('tr.ability-row .col-name').click((ev) => {
+      if (
+        $(ev.target).closest('.abilities-remove-row, .abilities-edit-row').length
+      )
+        return;
+      $(ev.currentTarget).closest('tr.ability-row').toggleClass('expanded');
     });
 
     // ������ "������" (���� ���-�� ������������)
@@ -253,9 +256,12 @@ export class myrpgActorSheet extends ActorSheet {
     // ----------------------------------------------------------------------
     // Mods table actions
     // ----------------------------------------------------------------------
-    html.find('.mods-section tr.mod-row').click((ev) => {
-      if ($(ev.target).closest('.mods-remove-row, .mods-edit-row').length) return;
-      $(ev.currentTarget).toggleClass('expanded');
+    html.find('.mods-section tr.mod-row .col-name').click((ev) => {
+      if (
+        $(ev.target).closest('.mods-remove-row, .mods-edit-row').length
+      )
+        return;
+      $(ev.currentTarget).closest('tr.mod-row').toggleClass('expanded');
     });
 
     html.find('.mods-add-row').click((ev) => {
@@ -397,9 +403,12 @@ export class myrpgActorSheet extends ActorSheet {
       this.actor.update({ 'system.inventoryList': inventory });
     });
 
-    html.find('.inventory tr.inventory-row').click((ev) => {
-      if ($(ev.target).closest('.inventory-remove-row, .inventory-edit-row').length) return;
-      $(ev.currentTarget).toggleClass('expanded');
+    html.find('.inventory tr.inventory-row .col-name').click((ev) => {
+      if (
+        $(ev.target).closest('.inventory-remove-row, .inventory-edit-row').length
+      )
+        return;
+      $(ev.currentTarget).closest('tr.inventory-row').toggleClass('expanded');
     });
 
     html.find('.inventory-edit-row').click((ev) => {

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.252",
+  "version": "2.253",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -431,7 +431,6 @@
               <tr>
                 <th class='col-name primary-header'>{{localize 'MY_RPG.AbilitiesTable.PrimaryHeader'}}</th>
                 <th class='col-rank'>{{localize 'MY_RPG.AbilitiesTable.Rank'}}</th>
-                <th class='col-effect'>{{localize 'MY_RPG.AbilitiesTable.Effect'}}</th>
                 <th class='col-cost'>{{localize 'MY_RPG.AbilitiesTable.Cost'}}</th>
                 <th class='col-delete'>
                   <a class='abilities-add-row' title='{{localize "MY_RPG.AbilitiesTable.AddRow"}}'>
@@ -445,9 +444,6 @@
                 <tr class='ability-row' data-index='{{i}}'>
                   <td class='col-name'>{{{row.name}}}</td>
                   <td class='col-rank'>{{row.rank}}</td>
-                  <td class='col-effect'>
-                    <div class='effect-wrapper'>{{{row.effect}}}</div>
-                  </td>
                   <td class='col-cost'>{{row.cost}}</td>
                   <td class='col-delete'>
                     <a class='abilities-edit-row' data-index='{{i}}'>
@@ -456,6 +452,11 @@
                     <a class='abilities-remove-row' data-index='{{i}}'>
                       <i class='fa-solid fa-trash'></i>
                     </a>
+                  </td>
+                </tr>
+                <tr class='ability-effect-row'>
+                  <td class='col-effect' colspan='4'>
+                    <div class='effect-wrapper'>{{{row.effect}}}</div>
                   </td>
                 </tr>
               {{/each}}
@@ -468,7 +469,6 @@
               <tr>
                 <th class='col-name primary-header'>{{localize 'MY_RPG.ModsTable.PrimaryHeader'}}</th>
                 <th class='col-rank'>{{localize 'MY_RPG.ModsTable.Rank'}}</th>
-                <th class='col-effect'>{{localize 'MY_RPG.ModsTable.Effect'}}</th>
                 <th class='col-cost'>{{localize 'MY_RPG.ModsTable.Cost'}}</th>
                 <th class='col-delete'>
                   <a class='mods-add-row' title='{{localize "MY_RPG.ModsTable.AddRow"}}'>
@@ -482,9 +482,6 @@
                 <tr class='mod-row' data-index='{{i}}'>
                   <td class='col-name'>{{{row.name}}}</td>
                   <td class='col-rank'>{{row.rank}}</td>
-                  <td class='col-effect'>
-                    <div class='effect-wrapper'>{{{row.effect}}}</div>
-                  </td>
                   <td class='col-cost'>{{row.cost}}</td>
                   <td class='col-delete'>
                     <a class='mods-edit-row' data-index='{{i}}'>
@@ -493,6 +490,11 @@
                     <a class='mods-remove-row' data-index='{{i}}'>
                       <i class='fa-solid fa-trash'></i>
                     </a>
+                  </td>
+                </tr>
+                <tr class='mod-effect-row'>
+                  <td class='col-effect' colspan='4'>
+                    <div class='effect-wrapper'>{{{row.effect}}}</div>
                   </td>
                 </tr>
               {{/each}}
@@ -566,7 +568,6 @@
             <thead>
               <tr>
                 <th class='col-name primary-header'>{{localize 'MY_RPG.Inventory.EquipmentHeader'}}</th>
-                <th class='col-effect'>{{localize 'MY_RPG.Inventory.Description'}}</th>
                 <th class='col-cost'>{{localize 'MY_RPG.Inventory.Quantity'}}</th>
                 <th class='col-delete'>
                   <a class='inventory-add-row' title='{{localize "MY_RPG.Inventory.AddRow"}}'>
@@ -579,9 +580,6 @@
               {{#each system.inventoryList as |item i|}}
                 <tr class='inventory-row' data-index='{{i}}'>
                   <td class='col-name'>{{{item.name}}}</td>
-                  <td class='col-effect'>
-                    <div class='effect-wrapper'>{{{item.desc}}}</div>
-                  </td>
                   <td class='col-cost'>
                     <a class='inventory-quantity-minus' data-index='{{i}}'>
                       <i class='fa-solid fa-minus'></i>
@@ -598,6 +596,11 @@
                     <a class='inventory-remove-row' data-index='{{i}}'>
                       <i class='fa-solid fa-trash'></i>
                     </a>
+                  </td>
+                </tr>
+                <tr class='inventory-effect-row'>
+                  <td class='col-effect' colspan='3'>
+                    <div class='effect-wrapper'>{{{item.desc}}}</div>
                   </td>
                 </tr>
               {{/each}}


### PR DESCRIPTION
## Summary
- update system version to 2.253
- remove effect column from all item tables
- show ability, mod and inventory descriptions below the row
- adjust table widths and disable row hover highlight
- trigger row expand only from the name column

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6870d4ca0be8832e90e9a0ab713f78ec