### PR TITLE
feat: improve skills layout

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -219,8 +219,19 @@ form input[type='number'] {
   margin-bottom: 5px;
 }
 
+
 .myrpg .skills .skill {
   margin-bottom: 5px;
+}
+
+/* layout skills into two columns */
+.skills-grid {
+  column-count: 2;
+  column-gap: 10px;
+}
+
+.skills-grid .skill-row {
+  break-inside: avoid;
 }
 
 /*         resizable   textarea */
@@ -249,6 +260,12 @@ form textarea {
 
 .rollable:hover,
 .rollable:focus {
+  color: #000;
+  text-shadow: 0 0 10px red;
+  cursor: pointer;
+}
+
+td.col-name:hover {
   color: #000;
   text-shadow: 0 0 10px red;
   cursor: pointer;

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.253",
+  "version": "2.254",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -304,11 +304,10 @@
         </div>
         <!--                sheet-box Key Info -->
 
-        <section class='flexrow'>
-          <!--       : 50% -->
-          <div class='flexcol col-50'>
-            <div class='sheet-box'>
-              <h2>{{localize 'MY_RPG.SheetLabels.Skills'}}</h2>
+        <section class='flexcol'>
+          <div class='sheet-box'>
+            <h2>{{localize 'MY_RPG.SheetLabels.Skills'}}</h2>
+            <div class='skills-grid'>
               {{#each system.skills as |skill key|}}
                 <div class='skill skill-row'>
                   <!--                                 -->
@@ -341,11 +340,9 @@
             </div>
           </div>
 
-
-          <div class='flexcol col-25'>
-            <div class='sheet-box limited-height'>
-              <h2>{{localize 'MY_RPG.TempBonus.Label'}}</h2>
-              <table>
+          <div class='sheet-box limited-height'>
+            <h2>{{localize 'MY_RPG.TempBonus.Label'}}</h2>
+            <table>
                 <tr>
                   <td>{{localize 'MY_RPG.TempHealth.Label'}}</td>
                   <td><input
@@ -396,9 +393,6 @@
                 </tr>
               </table>
             </div>
-          </div>
-
-
 
         </section>
 


### PR DESCRIPTION
## Summary
- make skills section fill two columns
- move temporary bonuses below the skills
- highlight item names on hover
- bump version to 2.254

## Testing
- `npx eslint .` *(fails: Cannot find package)*
- `npm install` *(fails: 404 Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_6870deb2870c832e8181f493ead4b8a9