### PR TITLE
Add chat share buttons and table styling

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -362,6 +362,18 @@ td.col-name:hover {
   text-align: center;
 }
 
+/* Bold text for table cells except effect rows */
+.abilities-table th,
+.abilities-table td:not(.col-effect) {
+  font-weight: 700;
+}
+
+/* Align first column to the left */
+.abilities-table th.col-name,
+.abilities-table td.col-name {
+  text-align: left;
+}
+
 .abilities-table td.col-cost a {
   display: inline-block;
   margin: 0 4px;

--- a/lang/en.json
+++ b/lang/en.json
@@ -130,6 +130,7 @@
     "TempSpeed": {
       "Label": "Temp. Speed"
     },
+    "SendToChat": "Send to Chat",
     "MinimalBonus": "minimal bonus",
     "abilityAbbreviations": {
       "spi": "Spi",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -130,6 +130,7 @@
     "TempSpeed": {
       "Label": "Врем. скорость"
     },
+    "SendToChat": "Отправить в чат",
     "MinimalBonus": "минимальный бонус",
     "abilityAbbreviations": {
       "spi": "Дух",

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -388,6 +388,66 @@ export class myrpgActorSheet extends ActorSheet {
       this._editDialog = diag;
     });
 
+    html.find('.inventory-chat-row').click((ev) => {
+      ev.preventDefault();
+      const index = Number(ev.currentTarget.dataset.index);
+      const item = this.actor.system.inventoryList[index] || {};
+      const lines = [`<strong>${item.name ?? ''}</strong>`];
+      if (item.quantity)
+        lines.push(
+          `${game.i18n.localize('MY_RPG.Inventory.Quantity')}: ${item.quantity}`
+        );
+      let content = lines.join('<br>');
+      if (item.desc) content += `<br><br>${item.desc}`;
+      ChatMessage.create({
+        content,
+        speaker: ChatMessage.getSpeaker({ actor: this.actor })
+      });
+    });
+
+    html.find('.mods-chat-row').click((ev) => {
+      ev.preventDefault();
+      const index = Number(ev.currentTarget.dataset.index);
+      const mod = this.actor.system.modsList[index] || {};
+      const lines = [`<strong>${mod.name ?? ''}</strong>`];
+      if (mod.rank)
+        lines.push(
+          `${game.i18n.localize('MY_RPG.ModsTable.Rank')}: ${mod.rank}`
+        );
+      if (mod.cost)
+        lines.push(
+          `${game.i18n.localize('MY_RPG.ModsTable.Cost')}: ${mod.cost}`
+        );
+      let content = lines.join('<br>');
+      if (mod.effect) content += `<br><br>${mod.effect}`;
+      ChatMessage.create({
+        content,
+        speaker: ChatMessage.getSpeaker({ actor: this.actor })
+      });
+    });
+
+    html.find('.abilities-chat-row').click((ev) => {
+      ev.preventDefault();
+      const index = Number(ev.currentTarget.dataset.index);
+      const ability = this.actor.system.abilitiesList[index] || {};
+      const lines = [`<strong>${ability.name ?? ''}</strong>`];
+      if (ability.rank)
+        lines.push(
+          `${game.i18n.localize('MY_RPG.ModsTable.Rank')}: ${ability.rank}`
+        );
+      if (ability.cost)
+        lines.push(
+          `${game.i18n.localize('MY_RPG.AbilitiesTable.Cost')}: ${ability.cost}`
+        );
+      let content = lines.join('<br>');
+      if (ability.effect)
+        content += `<br><br>${ability.effect}`;
+      ChatMessage.create({
+        content,
+        speaker: ChatMessage.getSpeaker({ actor: this.actor })
+      });
+    });
+
     // ----------------------------------------------------------------------
     // ������� ���������
     // ----------------------------------------------------------------------

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.254",
+  "version": "2.255",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -440,11 +440,26 @@
                   <td class='col-rank'>{{row.rank}}</td>
                   <td class='col-cost'>{{row.cost}}</td>
                   <td class='col-delete'>
-                    <a class='abilities-edit-row' data-index='{{i}}'>
+                    <a
+                      class='abilities-edit-row'
+                      data-index='{{i}}'
+                      title='{{localize "MY_RPG.AbilityConfig.Title"}}'
+                    >
                       <i class='fa-solid fa-pen'></i>
                     </a>
-                    <a class='abilities-remove-row' data-index='{{i}}'>
+                    <a
+                      class='abilities-remove-row'
+                      data-index='{{i}}'
+                      title='{{localize "MY_RPG.Dialog.ConfirmDeleteTitle"}}'
+                    >
                       <i class='fa-solid fa-trash'></i>
+                    </a>
+                    <a
+                      class='abilities-chat-row'
+                      data-index='{{i}}'
+                      title='{{localize "MY_RPG.SendToChat"}}'
+                    >
+                      <i class='fa-solid fa-comment-dots'></i>
                     </a>
                   </td>
                 </tr>
@@ -478,11 +493,26 @@
                   <td class='col-rank'>{{row.rank}}</td>
                   <td class='col-cost'>{{row.cost}}</td>
                   <td class='col-delete'>
-                    <a class='mods-edit-row' data-index='{{i}}'>
+                    <a
+                      class='mods-edit-row'
+                      data-index='{{i}}'
+                      title='{{localize "MY_RPG.AbilityConfig.Title"}}'
+                    >
                       <i class='fa-solid fa-pen'></i>
                     </a>
-                    <a class='mods-remove-row' data-index='{{i}}'>
+                    <a
+                      class='mods-remove-row'
+                      data-index='{{i}}'
+                      title='{{localize "MY_RPG.Dialog.ConfirmDeleteTitle"}}'
+                    >
                       <i class='fa-solid fa-trash'></i>
+                    </a>
+                    <a
+                      class='mods-chat-row'
+                      data-index='{{i}}'
+                      title='{{localize "MY_RPG.SendToChat"}}'
+                    >
+                      <i class='fa-solid fa-comment-dots'></i>
                     </a>
                   </td>
                 </tr>
@@ -584,11 +614,26 @@
                     </a>
                   </td>
                   <td class='col-delete'>
-                    <a class='inventory-edit-row' data-index='{{i}}'>
+                    <a
+                      class='inventory-edit-row'
+                      data-index='{{i}}'
+                      title='{{localize "MY_RPG.Inventory.EditTitle"}}'
+                    >
                       <i class='fa-solid fa-pen'></i>
                     </a>
-                    <a class='inventory-remove-row' data-index='{{i}}'>
+                    <a
+                      class='inventory-remove-row'
+                      data-index='{{i}}'
+                      title='{{localize "MY_RPG.Inventory.ConfirmDeleteTitle"}}'
+                    >
                       <i class='fa-solid fa-trash'></i>
+                    </a>
+                    <a
+                      class='inventory-chat-row'
+                      data-index='{{i}}'
+                      title='{{localize "MY_RPG.SendToChat"}}'
+                    >
+                      <i class='fa-solid fa-comment-dots'></i>
                     </a>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- format ability and inventory tables with bold entries and left-aligned first column
- add buttons to send ability, mod and inventory rows to chat
- introduce localisation for the chat button
- bump version to 2.255

## Testing
- `npx eslint .` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6870ee710d48832eb951c98116d427c3