### PR TITLE
Fix armor update and bonus display

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -541,7 +541,8 @@ export class myrpgActorSheet extends ActorSheet {
             itemMental: formData.itemMental ?? 0,
             itemShield: formData.itemShield ?? 0,
             itemSpeed: formData.itemSpeed ?? 0,
-            quantity: formData.quantity ?? 1
+            quantity: formData.quantity ?? 1,
+            equipped: itemData.equipped ?? false
           };
           this.actor.update({ 'system.armorList': list });
           this._editDialog = null;
@@ -558,16 +559,17 @@ export class myrpgActorSheet extends ActorSheet {
             for (let [k, v] of fd.entries()) {
               formData[k] = v;
             }
-            list[index] = {
-              name: formData.name ?? '',
-              desc: formData.desc ?? '',
-              itemPhys: formData.itemPhys ?? 0,
-              itemAzure: formData.itemAzure ?? 0,
-              itemMental: formData.itemMental ?? 0,
-              itemShield: formData.itemShield ?? 0,
-              itemSpeed: formData.itemSpeed ?? 0,
-              quantity: formData.quantity ?? 1
-            };
+              list[index] = {
+                name: formData.name ?? '',
+                desc: formData.desc ?? '',
+                itemPhys: formData.itemPhys ?? 0,
+                itemAzure: formData.itemAzure ?? 0,
+                itemMental: formData.itemMental ?? 0,
+                itemShield: formData.itemShield ?? 0,
+                itemSpeed: formData.itemSpeed ?? 0,
+                quantity: formData.quantity ?? 1,
+                equipped: list[index].equipped ?? false
+              };
             this.actor.update({ 'system.armorList': list }, { render: false });
 
             const row = this.element.find(`.abilities-table tr.armor-row[data-index="${index}"]`);

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.260",
+  "version": "2.261",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -566,7 +566,39 @@
                 </tr>
                 <tr class='armor-effect-row'>
                   <td class='col-effect' colspan='4'>
-                    <div class='effect-wrapper'>{{{item.desc}}}</div>
+                    <div class='effect-wrapper'>
+                      {{#if item.itemPhys}}
+                        <div>
+                          {{localize 'MY_RPG.ArmorItem.BonusPhysicalLabel'}}:
+                          {{item.itemPhys}}
+                        </div>
+                      {{/if}}
+                      {{#if item.itemAzure}}
+                        <div>
+                          {{localize 'MY_RPG.ArmorItem.BonusMagicalLabel'}}:
+                          {{item.itemAzure}}
+                        </div>
+                      {{/if}}
+                      {{#if item.itemMental}}
+                        <div>
+                          {{localize 'MY_RPG.ArmorItem.BonusPsychicLabel'}}:
+                          {{item.itemMental}}
+                        </div>
+                      {{/if}}
+                      {{#if item.itemShield}}
+                        <div>
+                          {{localize 'MY_RPG.ArmorItem.ShieldLabel'}}:
+                          {{item.itemShield}}
+                        </div>
+                      {{/if}}
+                      {{#if item.itemSpeed}}
+                        <div>
+                          {{localize 'MY_RPG.ArmorItem.BonusSpeedLabel'}}:
+                          {{item.itemSpeed}}
+                        </div>
+                      {{/if}}
+                      {{{item.desc}}}
+                    </div>
                   </td>
                 </tr>
               {{/each}}


### PR DESCRIPTION
## Summary
- keep equipped status when editing armor
- list armor bonuses on sheet
- bump version to 2.261

## Testing
- `npm test` *(fails: no test specified)*
- `npx eslint .` *(fails: cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68712c9b0f1c832eabf7df78b7523c73