### PR TITLE
feat: unity runes improvements

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -315,7 +315,7 @@ td.col-name:hover {
 }
 
 .tab.abilities table.abilities-table th.col-name {
-  width: 37% !important;
+  width: 24% !important;
 }
 
 .tab.abilities table.abilities-table th.col-rank {

--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -326,6 +326,10 @@ td.col-name:hover {
   width: 11% !important;
 }
 
+.tab.abilities table.abilities-table th.col-type {
+  width: 13% !important;
+}
+
 .tab.abilities table.abilities-table th.col-upg1 {
   width: 13% !important;
 }
@@ -776,4 +780,14 @@ input.rank5 {
 .rank-hint-table td.rank5 {
   background-color: var(--rank-bg);
   color: #1b1210;
+}
+
+.rune-size {
+  margin-bottom: 10px;
+  text-align: right;
+}
+
+.rune-size input {
+  width: 3em;
+  text-align: center;
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -69,6 +69,7 @@
     },
     "SheetLabels": {
       "AbilitiesAndMods": "Abilities and Mods",
+      "Tablet": "Tablet",
       "Features": "Main Sheet",
       "Abilities": "Abilities",
       "Parameters": "Parameters",
@@ -86,6 +87,7 @@
       "Rank": "Rank",
       "Effect": "Effect",
       "Cost": "Cost",
+      "RuneType": "Rune Type",
       "Upgrade1": "Upgrade 1",
       "Upgrade2": "Upgrade 2",
       "AlreadyEditing": "An edit dialog is already open. Please close it before opening another."
@@ -99,6 +101,14 @@
       "Duration": "Duration",
       "Activations": "Activations",
       "Link": "Link"
+    },
+    "RuneTypes": {
+      "Spell": "Spell",
+      "Creature": "Creature",
+      "Item": "Item",
+      "Portal": "Portal",
+      "Domain": "Domain",
+      "Saga": "Saga"
     },
     "Health": {
       "Label": "Health Points (HP)",
@@ -223,6 +233,19 @@
       "Upgrade2": "Upgrade 2",
       "AddRow": "Add Row",
       "Rank": "Rank"
+    },
+    "RunesTable": {
+      "TableHeading": "Runes",
+      "PrimaryHeader": "Runes",
+      "Name": "Name",
+      "Effect": "Effect",
+      "Cost": "Cost",
+      "RuneType": "Rune Type",
+      "Upgrade1": "Upgrade 1",
+      "Upgrade2": "Upgrade 2",
+      "AddRow": "Add Rune",
+      "Rank": "Rank",
+      "SizeLabel": "Tablet Size"
     },
     "ModsTable": {
       "TableHeading": "Skills and Mods",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -81,6 +81,7 @@
     },
     "SheetLabels": {
       "AbilitiesAndMods": "Способности и модификации",
+      "Tablet": "Скрижаль",
       "Features": "Основной лист",
       "Abilities": "Способности",
       "Parameters": "Параметры",
@@ -114,6 +115,7 @@
       "Rank": "Ранг",
       "Effect": "Эффект",
       "Cost": "Стоимость",
+      "RuneType": "Тип руны",
       "Upgrade1": "Улучшение 1",
       "Upgrade2": "Улучшение 2",
       "AlreadyEditing": "Диалог редактирования уже открыт. Сначала закройте его."
@@ -127,6 +129,14 @@
       "Duration": "Длительность",
       "Activations": "Активации",
       "Link": "Связь"
+    },
+    "RuneTypes": {
+      "Spell": "Заклинание",
+      "Creature": "Существо",
+      "Item": "Предмет",
+      "Portal": "Портал",
+      "Domain": "Домен",
+      "Saga": "Сага"
     },
     "Initiative": "Инициатива",
     "Health": {
@@ -223,6 +233,19 @@
       "Upgrade2": "Улучшение 2",
       "AddRow": "Добавить строку",
       "Rank": "Ранг"
+    },
+    "RunesTable": {
+      "TableHeading": "Руны",
+      "PrimaryHeader": "Руны",
+      "Name": "Название",
+      "Effect": "Эффект",
+      "Cost": "Стоимость",
+      "RuneType": "Тип руны",
+      "Upgrade1": "Улучшение 1",
+      "Upgrade2": "Улучшение 2",
+      "AddRow": "Добавить руну",
+      "Rank": "Ранг",
+      "SizeLabel": "Размер Скрижали"
     },
     "ModsTable": {
       "TableHeading": "Умения и модификации",

--- a/module/helpers/handlebars-helpers.mjs
+++ b/module/helpers/handlebars-helpers.mjs
@@ -71,3 +71,21 @@ Handlebars.registerHelper('armorEffect', function (item) {
   if (item.desc) html += `<br><br>${item.desc}`;
   return new Handlebars.SafeString(html);
 });
+
+// Conditionally render content only for the Unity world
+Handlebars.registerHelper('ifUnity', function (options) {
+  const mode = game.settings.get('myrpg', 'worldType');
+  return mode === 'unity' ? options.fn(this) : options.inverse(this);
+});
+
+// Choose localisation key based on world mode
+Handlebars.registerHelper('worldChoice', function (unityKey, stellarKey) {
+  const mode = game.settings.get('myrpg', 'worldType');
+  return mode === 'unity' ? unityKey : stellarKey;
+});
+
+// Calculate rune tablet maximum size
+Handlebars.registerHelper('calcRuneMax', function (system) {
+  const mind = Number(system.abilities?.int?.value || 0);
+  return mind * 2 + 5;
+});

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.267",
+  "version": "2.268",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -4,9 +4,7 @@
   <div class='sheet-tabs-hex-container'>
     <nav class='sheet-tabs-hex' data-group='primary'>
       <a class='hex-button' data-tab='features'>{{localize 'MY_RPG.SheetLabels.Features'}}</a>
-      <a class='hex-button' data-tab='abilities'>{{localize
-          'MY_RPG.SheetLabels.AbilitiesAndMods'
-        }}</a>
+      <a class='hex-button' data-tab='abilities'>{{localize (worldChoice 'MY_RPG.SheetLabels.Tablet' 'MY_RPG.SheetLabels.AbilitiesAndMods')}}</a>
       <a class='hex-button' data-tab='inventory'>{{localize 'MY_RPG.SheetLabels.Inventory'}}</a>
       <a class='hex-button' data-tab='biography'>{{localize 'MY_RPG.SheetLabels.Biography'}}</a>
     </nav>
@@ -400,13 +398,23 @@
       <!--               Features -->
 
       <div class='tab abilities' data-group='primary' data-tab='abilities'>
+        {{#ifUnity}}
+        <div class='rune-size'>
+          <label>{{localize 'MY_RPG.RunesTable.SizeLabel'}}</label>
+          <input type='number' value='{{system.abilitiesList.length}}' disabled /> /
+          <input type='number' value='{{runeMax}}' disabled />
+        </div>
+        {{/ifUnity}}
         <section class='abilities-section'>
           <table class='abilities-table'>
             <thead>
               <tr>
-                <th class='col-name primary-header'>{{localize 'MY_RPG.AbilitiesTable.PrimaryHeader'}}</th>
+                <th class='col-name primary-header'>{{localize (worldChoice 'MY_RPG.RunesTable.PrimaryHeader' 'MY_RPG.AbilitiesTable.PrimaryHeader')}}</th>
                 <th class='col-rank'>{{localize 'MY_RPG.AbilitiesTable.Rank'}}</th>
                 <th class='col-cost'>{{localize 'MY_RPG.AbilitiesTable.Cost'}}</th>
+                {{#ifUnity}}
+                <th class='col-type'>{{localize 'MY_RPG.RunesTable.RuneType'}}</th>
+                {{/ifUnity}}
                 <th class='col-upg1'>{{localize 'MY_RPG.AbilitiesTable.Upgrade1'}}</th>
                 <th class='col-upg2'>{{localize 'MY_RPG.AbilitiesTable.Upgrade2'}}</th>
                 <th class='col-delete'>
@@ -422,6 +430,9 @@
                   <td class='col-name'>{{{row.name}}}</td>
                   <td class='col-rank'>{{row.rank}}</td>
                   <td class='col-cost'>{{row.cost}}</td>
+                  {{#ifUnity}}
+                  <td class='col-type'>{{localize (concat 'MY_RPG.RuneTypes.' row.runeType)}}</td>
+                  {{/ifUnity}}
                   <td class='col-upg1'>{{localize (concat 'MY_RPG.AbilityUpgrades.' row.upgrade1)}}</td>
                   <td class='col-upg2'>{{localize (concat 'MY_RPG.AbilityUpgrades.' row.upgrade2)}}</td>
                   <td class='col-delete'>
@@ -449,7 +460,7 @@
                   </td>
                 </tr>
                 <tr class='ability-effect-row'>
-                  <td class='col-effect' colspan='6'>
+                  <td class='col-effect' colspan='{{#ifUnity}}7{{else}}6{{/ifUnity}}'>
                     <div class='effect-wrapper'>{{{row.effect}}}</div>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- add world-aware handlebars helpers
- rename abilities tab to Tablet in Unity and add rune type column
- track rune type and tablet size in Unity mode
- bump version to 2.268

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687268c19d44832ea688957abb923369