### PR TITLE
Fix rune tablet size layout

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -788,6 +788,11 @@ input.rank5 {
 }
 
 .rune-size input {
-  width: 3em;
+  width: 2.5em;
   text-align: center;
+}
+
+.rune-size .divider {
+  font-weight: bold;
+  margin: 0 0.2em;
 }

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.268",
+  "version": "2.269",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -401,7 +401,8 @@
         {{#ifUnity}}
         <div class='rune-size'>
           <label>{{localize 'MY_RPG.RunesTable.SizeLabel'}}</label>
-          <input type='number' value='{{system.abilitiesList.length}}' disabled /> /
+          <input type='number' value='{{system.abilitiesList.length}}' disabled />
+          <span class='divider'>/</span>
           <input type='number' value='{{runeMax}}' disabled />
         </div>
         {{/ifUnity}}


### PR DESCRIPTION
## Summary
- make the rune tablet size fields smaller and add bold divider
- bump version to 2.269

## Checklist
- [x] Localization updated
- [x] Version bumped
- [ ] ESLint & tests pass


------
https://chatgpt.com/codex/tasks/task_e_687277842eec832e85ad0426d88c494c