### PR TITLE
feat: improve rune tablet size display

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -784,11 +784,16 @@ input.rank5 {
 
 .rune-size {
   margin-bottom: 10px;
-  text-align: right;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 700;
+  font-size: 1.1em;
 }
 
 .rune-size input {
-  width: 2.5em;
+  width: 2.5em !important;
   text-align: center;
 }
 

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.269",
+  "version": "2.270",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
## Summary
- center rune size field and bold label
- bump version to 2.270

## Testing
- `npm test` *(fails: no test specified)*
- `npm ci` *(fails: 404 fetching prettier-plugin-handlebars)*

------
https://chatgpt.com/codex/tasks/task_e_68727e751b7c832ea6f807946c3bedf5