### PR TITLE
feat: skill rank dropdowns

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -5,6 +5,12 @@
 
 import { getColorRank } from '../helpers/utils.mjs';
 
+function getRankLabel(rank) {
+  const mode = game.settings.get('myrpg', 'worldType');
+  const base = mode === 'stellar' ? 'MY_RPG.RankNumeric' : 'MY_RPG.RankGradient';
+  return game.i18n.localize(`${base}.Rank${rank}`);
+}
+
 export class myrpgActorSheet extends ActorSheet {
   _editDialog = null;
   /** @override */
@@ -211,6 +217,19 @@ export class myrpgActorSheet extends ActorSheet {
         )
         .join('');
 
+      const baseRank =
+        game.settings.get('myrpg', 'worldType') === 'stellar'
+          ? 'MY_RPG.RankNumeric'
+          : 'MY_RPG.RankGradient';
+      const optionsRank = [1, 2, 3, 4, 5]
+        .map(
+          (r) =>
+            `<option value="${r}" ${Number(abilityData.rank || 0) === r ? 'selected' : ''}>${game.i18n.localize(
+              baseRank + '.Rank' + r
+            )}</option>`
+        )
+        .join('');
+
       let diag = new Dialog({
         title: game.i18n.localize('MY_RPG.AbilityConfig.Title'),
         content: `
@@ -221,7 +240,7 @@ export class myrpgActorSheet extends ActorSheet {
             </div>
             <div class="form-group">
               <label>${game.i18n.localize('MY_RPG.AbilityConfig.Rank')}</label>
-              <input type="text" name="rank" value="${abilityData.rank ?? ''}" />
+              <select name="rank">${optionsRank}</select>
             </div>
             <div class="form-group">
               <label>${game.i18n.localize('MY_RPG.AbilityConfig.Effect')}</label>
@@ -301,7 +320,11 @@ export class myrpgActorSheet extends ActorSheet {
               `.abilities-table tr.ability-row[data-index="${index}"]`
             );
             row.find('.col-name').html(formData.name ?? '');
-            row.find('.col-rank').text(formData.rank ?? '');
+            row
+              .find('.col-rank')
+              .text(
+                formData.rank ? getRankLabel(Number(formData.rank)) : ''
+              );
             row.find('.col-effect .effect-wrapper').html(formData.effect ?? '');
             row.find('.col-cost').text(formData.cost ?? '');
             if (isUnity)
@@ -352,7 +375,6 @@ export class myrpgActorSheet extends ActorSheet {
         name: '',
         rank: '',
         effect: '',
-        cost: '',
         upgrade1: 'None',
         upgrade2: 'None'
       });
@@ -422,6 +444,19 @@ export class myrpgActorSheet extends ActorSheet {
         )
         .join('');
 
+      const baseRank =
+        game.settings.get('myrpg', 'worldType') === 'stellar'
+          ? 'MY_RPG.RankNumeric'
+          : 'MY_RPG.RankGradient';
+      const optionsRank = [1, 2, 3, 4, 5]
+        .map(
+          (r) =>
+            `<option value="${r}" ${Number(modData.rank || 0) === r ? 'selected' : ''}>${game.i18n.localize(
+              baseRank + '.Rank' + r
+            )}</option>`
+        )
+        .join('');
+
       let diag = new Dialog({
         title: game.i18n.localize('MY_RPG.AbilityConfig.Title'),
         content: `
@@ -432,15 +467,11 @@ export class myrpgActorSheet extends ActorSheet {
             </div>
             <div class="form-group">
               <label>${game.i18n.localize('MY_RPG.AbilityConfig.Rank')}</label>
-              <input type="text" name="rank" value="${modData.rank ?? ''}" />
+              <select name="rank">${optionsRank}</select>
             </div>
             <div class="form-group">
               <label>${game.i18n.localize('MY_RPG.AbilityConfig.Effect')}</label>
               <textarea name="effect" class="rich-editor">${modData.effect ?? ''}</textarea>
-            </div>
-            <div class="form-group">
-              <label>${game.i18n.localize('MY_RPG.AbilityConfig.Cost')}</label>
-              <input type="number" name="cost" value="${modData.cost ?? ''}" />
             </div>
             <div class="form-group">
               <label>${game.i18n.localize('MY_RPG.AbilityConfig.Upgrade1')}</label>
@@ -465,7 +496,6 @@ export class myrpgActorSheet extends ActorSheet {
             name: formData.name ?? '',
             rank: formData.rank ?? '',
             effect: formData.effect ?? '',
-            cost: formData.cost ?? '',
             upgrade1: formData.upgrade1 ?? '',
             upgrade2: formData.upgrade2 ?? ''
           };
@@ -490,7 +520,6 @@ export class myrpgActorSheet extends ActorSheet {
               name: formData.name ?? '',
               rank: formData.rank ?? '',
               effect: formData.effect ?? '',
-              cost: formData.cost ?? '',
               upgrade1: formData.upgrade1 ?? '',
               upgrade2: formData.upgrade2 ?? ''
             };
@@ -503,9 +532,12 @@ export class myrpgActorSheet extends ActorSheet {
               `.mods-table tr.mod-row[data-index="${index}"]`
             );
             row.find('.col-name').html(formData.name ?? '');
-            row.find('.col-rank').text(formData.rank ?? '');
+            row
+              .find('.col-rank')
+              .text(
+                formData.rank ? getRankLabel(Number(formData.rank)) : ''
+              );
             row.find('.col-effect .effect-wrapper').html(formData.effect ?? '');
-            row.find('.col-cost').text(formData.cost ?? '');
             row
               .find('.col-upg1')
               .text(
@@ -551,11 +583,7 @@ export class myrpgActorSheet extends ActorSheet {
       const lines = [`<strong>${mod.name ?? ''}</strong>`];
       if (mod.rank)
         lines.push(
-          `${game.i18n.localize('MY_RPG.ModsTable.Rank')}: ${mod.rank}`
-        );
-      if (mod.cost)
-        lines.push(
-          `${game.i18n.localize('MY_RPG.ModsTable.Cost')}: ${mod.cost}`
+          `${game.i18n.localize('MY_RPG.ModsTable.Rank')}: ${getRankLabel(mod.rank)}`
         );
       if (mod.upgrade1 && mod.upgrade1 !== 'None')
         lines.push(
@@ -584,7 +612,9 @@ export class myrpgActorSheet extends ActorSheet {
       const lines = [`<strong>${ability.name ?? ''}</strong>`];
       if (ability.rank)
         lines.push(
-          `${game.i18n.localize('MY_RPG.ModsTable.Rank')}: ${ability.rank}`
+          `${game.i18n.localize('MY_RPG.ModsTable.Rank')}: ${getRankLabel(
+            ability.rank
+          )}`
         );
       if (ability.cost)
         lines.push(

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.271",
+  "version": "2.272",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -429,7 +429,7 @@
               {{#each system.abilitiesList as |row i|}}
                 <tr class='ability-row' data-index='{{i}}'>
                   <td class='col-name'>{{{row.name}}}</td>
-                  <td class='col-rank'>{{row.rank}}</td>
+                  <td class='col-rank'>{{rankLabel row.rank}}</td>
                   <td class='col-cost'>{{row.cost}}</td>
                   {{#ifUnity}}
                   <td class='col-type'>{{localize (concat 'MY_RPG.RuneTypes.' row.runeType)}}</td>
@@ -475,7 +475,6 @@
               <tr>
                 <th class='col-name primary-header'>{{localize 'MY_RPG.ModsTable.PrimaryHeader'}}</th>
                 <th class='col-rank'>{{localize 'MY_RPG.ModsTable.Rank'}}</th>
-                <th class='col-cost'>{{localize 'MY_RPG.ModsTable.Cost'}}</th>
                 <th class='col-upg1'>{{localize 'MY_RPG.ModsTable.Upgrade1'}}</th>
                 <th class='col-upg2'>{{localize 'MY_RPG.ModsTable.Upgrade2'}}</th>
                 <th class='col-delete'>
@@ -489,11 +488,10 @@
               {{#each system.modsList as |row i|}}
                 <tr class='mod-row' data-index='{{i}}'>
                   <td class='col-name'>{{{row.name}}}</td>
-                  <td class='col-rank'>{{row.rank}}</td>
-                  <td class='col-cost'>{{row.cost}}</td>
-                  <td class='col-upg1'>{{localize (concat 'MY_RPG.AbilityUpgrades.' row.upgrade1)}}</td>
-                  <td class='col-upg2'>{{localize (concat 'MY_RPG.AbilityUpgrades.' row.upgrade2)}}</td>
-                  <td class='col-delete'>
+                  <td class='col-rank'>{{rankLabel row.rank}}</td>
+                <td class='col-upg1'>{{localize (concat 'MY_RPG.AbilityUpgrades.' row.upgrade1)}}</td>
+                <td class='col-upg2'>{{localize (concat 'MY_RPG.AbilityUpgrades.' row.upgrade2)}}</td>
+                <td class='col-delete'>
                     <a
                       class='mods-chat-row'
                       data-index='{{i}}'
@@ -518,7 +516,7 @@
                   </td>
                 </tr>
                 <tr class='mod-effect-row'>
-                  <td class='col-effect' colspan='6'>
+                  <td class='col-effect' colspan='5'>
                     <div class='effect-wrapper'>{{{row.effect}}}</div>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- drop cost column from skills table
- show rank options via dropdown for abilities and skills
- display localized rank labels in tables
- bump version to 2.272

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6872dff24d50832e92ab9e85fd72a39b