### PR TITLE
Fix force shield contribution to stress capacity

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -64,12 +64,16 @@ export class myrpgActor extends Actor {
 
   _calcStressMax(s) {
     const rank = Math.max(Number(s.currentRank) || 0, 0);
-    return Math.max(0, rank + 4);
+    const tempHealth = Math.max(Number(s.temphealth) || 0, 0);
+    const forceShield = Math.max(this._sumArmor(s.armorList, 'itemShield'), 0);
+    return Math.max(0, rank + 4 + tempHealth + forceShield);
   }
 
   _calcNpcStressMax(s) {
     const rank = Math.max(Number(s.currentRank) || 0, 0);
-    return Math.max(0, 6 + rank);
+    const tempHealth = Math.max(Number(s.temphealth) || 0, 0);
+    const forceShield = Math.max(this._sumArmor(s.armorList, 'itemShield'), 0);
+    return Math.max(0, 6 + rank + tempHealth + forceShield);
   }
 
   _calcFlux(s) {

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.287",
+  "version": "2.288",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
## Summary
- include armor force shield and temporary HP bonuses when computing stress limits for characters and NPCs
- bump the system manifest version to 2.288

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68fe442b27ec832e85358c2432353ef8