### PR TITLE
fix: align weapon table columns

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -477,23 +477,23 @@ td.col-name:hover {
 }
 
 .tab.inventory table.weapon-table th.col-name {
-  width: 46%;
-}
-
-.tab.inventory table.weapon-table th.col-skill {
-  width: 20%;
+  width: 44%;
 }
 
 .tab.inventory table.weapon-table th.col-bonus {
-  width: 12%;
+  width: 14%;
+}
+
+.tab.inventory table.weapon-table th.col-skill {
+  width: 14%;
 }
 
 .tab.inventory table.weapon-table th.col-equip {
-  width: 10%;
+  width: 12%;
 }
 
 .tab.inventory table.weapon-table th.col-delete {
-  width: 12%;
+  width: 16%;
 }
 
 .tab.inventory table.weapon-table td.col-equip {

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.290",
+  "version": "2.291",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -579,8 +579,8 @@
             <thead>
               <tr>
                 <th class='col-name primary-header'>{{localize 'MY_RPG.WeaponsTable.SectionTitle'}}</th>
-                <th class='col-skill'>{{localize 'MY_RPG.WeaponsTable.SkillLabel'}}</th>
                 <th class='col-bonus'>{{localize 'MY_RPG.WeaponsTable.BonusLabel'}}</th>
+                <th class='col-skill'>{{localize 'MY_RPG.WeaponsTable.SkillLabel'}}</th>
                 <th class='col-equip'>{{localize 'MY_RPG.WeaponsTable.EquippedLabel'}}</th>
                 <th class='col-delete'>
                   <a class='weapon-add-row' title='{{localize "MY_RPG.WeaponsTable.AddRow"}}'>
@@ -593,8 +593,8 @@
               {{#each system.weaponList as |weapon i|}}
                 <tr class='weapon-row' data-index='{{i}}'>
                   <td class='col-name'>{{{weapon.name}}}</td>
-                  <td class='col-skill'>{{skillLabel weapon.skill}}</td>
                   <td class='col-bonus'>{{formatWeaponBonus weapon.skillBonus}}</td>
+                  <td class='col-skill'>{{skillLabel weapon.skill}}</td>
                   <td class='col-equip'>
                     <input
                       type='checkbox'


### PR DESCRIPTION
## Summary
- reorder the weapon table columns so the separators match the armor layout
- tune the weapon column widths to align visually with the armor table
- bump the system manifest version to 2.291

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe57db7638832ea54d6ae83e0c41c1