### PR TITLE
Add item document support and sheets

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -195,7 +195,7 @@ textarea[disabled] {
   padding-right: 0;
 }
 
-.col-33 {
+.col-33 { 
   flex: 0 0 33.33%;
   padding-right: 10px;
 }
@@ -886,4 +886,56 @@ input.rank5 {
 .rune-size .divider {
   font-weight: bold;
   margin: 0 0.2em;
+}
+
+.myrpg-item-sheet {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.myrpg-item-header .item-meta-grid {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.myrpg-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.myrpg-item-body .item-section {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.myrpg-item-body .item-section .form-group,
+.myrpg-item-body .item-section > label {
+  flex: 1 1 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.myrpg-item-body textarea,
+.myrpg-item-body input[type='text'],
+.myrpg-item-body input[type='number'] {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.myrpg-item-bonuses-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.myrpg-item-bonuses-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -77,7 +77,8 @@
       "Skills": "Skills",
       "KeyInfo": "Key Information",
       "Biography": "Biography & Notes",
-      "Inventory": "Inventory"
+      "Inventory": "Inventory",
+      "Item": "Item"
     },
     "AbilityConfig": {
       "Title": "Edit Ability",
@@ -122,6 +123,56 @@
       "Severe": "Severe Wound",
       "SevereAbbrev": "S",
       "SevereAria": "Toggle severe wound"
+    },
+    "Item": {
+      "General": {
+        "Quantity": "Quantity",
+        "Equipped": "Equipped",
+        "Description": "Description",
+        "Notes": "Notes",
+        "Slot": "Slot",
+        "NamePlaceholder": "Item Name"
+      },
+      "Bonuses": {
+        "Section": "Bonuses",
+        "Physical": "Physical Protection",
+        "Arcane": "Arcane Protection",
+        "Mental": "Mental Protection",
+        "Shield": "Force Shield",
+        "Speed": "Speed Bonus",
+        "Attack": "Attack Bonus"
+      },
+      "Ability": {
+        "Rank": "Rank",
+        "Cost": "Cost",
+        "Effect": "Effect"
+      },
+      "Mod": {
+        "Effect": "Effect",
+        "Slot": "Slot"
+      },
+      "Armor": {
+        "Category": "Armor Category",
+        "Coverage": "Coverage"
+      },
+      "Weapon": {
+        "Skill": "Associated Skill",
+        "Damage": "Damage",
+        "Range": "Range",
+        "Properties": "Properties"
+      },
+      "Gear": {
+        "Uses": "Uses",
+        "Weight": "Weight",
+        "Rarity": "Rarity"
+      },
+      "SheetTitle": {
+        "ability": "Ability",
+        "mod": "Modification",
+        "armor": "Armor",
+        "weapon": "Weapon",
+        "gear": "Gear"
+      }
     },
     "ArmorItem": {
       "BonusPhysicalLabel": "Bonus to Physical Protection",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -43,6 +43,56 @@
       "Rank4": "Ранг 4",
       "Rank5": "Ранг 5"
     },
+    "Item": {
+      "General": {
+        "Quantity": "Количество",
+        "Equipped": "Экипировано",
+        "Description": "Описание",
+        "Notes": "Заметки",
+        "Slot": "Слот",
+        "NamePlaceholder": "Название предмета"
+      },
+      "Bonuses": {
+        "Section": "Бонусы",
+        "Physical": "Защита (физ.)",
+        "Arcane": "Защита (азур.)",
+        "Mental": "Защита (ментал.)",
+        "Shield": "Силовой щит",
+        "Speed": "Бонус к скорости",
+        "Attack": "Бонус к атаке"
+      },
+      "Ability": {
+        "Rank": "Ранг",
+        "Cost": "Стоимость",
+        "Effect": "Эффект"
+      },
+      "Mod": {
+        "Effect": "Эффект",
+        "Slot": "Слот"
+      },
+      "Armor": {
+        "Category": "Категория брони",
+        "Coverage": "Покрытие"
+      },
+      "Weapon": {
+        "Skill": "Связанный навык",
+        "Damage": "Урон",
+        "Range": "Дистанция",
+        "Properties": "Свойства"
+      },
+      "Gear": {
+        "Uses": "Применения",
+        "Weight": "Вес",
+        "Rarity": "Редкость"
+      },
+      "SheetTitle": {
+        "ability": "Способность",
+        "mod": "Модификация",
+        "armor": "Броня",
+        "weapon": "Оружие",
+        "gear": "Снаряжение"
+      }
+    },
     "ArmorItem": {
       "ArmorSectionTitle": "Доспех",
       "DescriptionLabel": "Описание",
@@ -102,7 +152,8 @@
       "Skills": "Навыки",
       "KeyInfo": "Ключевая информация",
       "Biography": "Биография и заметки",
-      "Inventory": "Инвентарь"
+      "Inventory": "Инвентарь",
+      "Item": "Предмет"
     },
     "Inventory": {
       "TableHeading": "Инвентарь",

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1,0 +1,82 @@
+export class myrpgItem extends Item {
+  /** @override */
+  prepareBaseData() {
+    super.prepareBaseData();
+    const systemData = this.system ?? (this.system = {});
+
+    const baseDefaults = {
+      description: '',
+      notes: '',
+      equipped: false,
+      quantity: 1,
+      bonuses: {
+        physical: 0,
+        arcane: 0,
+        mental: 0,
+        shield: 0,
+        speed: 0,
+        attack: 0
+      }
+    };
+
+    const typeDefaults = {
+      ability: {
+        rank: '',
+        cost: '',
+        effect: ''
+      },
+      mod: {
+        slot: '',
+        effect: ''
+      },
+      armor: {
+        category: '',
+        coverage: ''
+      },
+      weapon: {
+        skill: '',
+        damage: '',
+        range: '',
+        properties: ''
+      },
+      gear: {
+        uses: '',
+        weight: '',
+        rarity: ''
+      }
+    };
+
+    foundry.utils.mergeObject(systemData, baseDefaults, {
+      inplace: true,
+      overwrite: false
+    });
+
+    const bonuses = systemData.bonuses ?? (systemData.bonuses = {});
+    foundry.utils.mergeObject(bonuses, baseDefaults.bonuses, {
+      inplace: true,
+      overwrite: false
+    });
+
+    const specific = typeDefaults[this.type];
+    if (specific) {
+      foundry.utils.mergeObject(systemData, specific, {
+        inplace: true,
+        overwrite: false
+      });
+    }
+  }
+
+  /** @override */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    this.debugState();
+  }
+
+  debugState() {
+    console.debug('[MyRPG] Item prepared', {
+      name: this.name,
+      type: this.type,
+      system: foundry.utils.deepClone(this.system ?? {})
+    });
+  }
+}

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -6,7 +6,12 @@
 export const preloadHandlebarsTemplates = async function () {
   const paths = [
     'systems/myrpg/templates/actor/actor-character-sheet.hbs',
-    'systems/myrpg/templates/actor/actor-npc-sheet.hbs'
+    'systems/myrpg/templates/actor/actor-npc-sheet.hbs',
+    'systems/myrpg/templates/item/ability-sheet.hbs',
+    'systems/myrpg/templates/item/mod-sheet.hbs',
+    'systems/myrpg/templates/item/armor-sheet.hbs',
+    'systems/myrpg/templates/item/weapon-sheet.hbs',
+    'systems/myrpg/templates/item/gear-sheet.hbs'
   ];
   return loadTemplates(paths);
 };

--- a/module/myrpg.mjs
+++ b/module/myrpg.mjs
@@ -1,7 +1,9 @@
 // Import document classes.
 import { myrpgActor } from './documents/actor.mjs';
+import { myrpgItem } from './documents/item.mjs';
 // Import sheet classes.
 import { myrpgActorSheet } from './sheets/actor-sheet.mjs';
+import { myrpgItemSheet } from './sheets/item-sheet.mjs';
 // Import helper/utility classes and constants.
 import { preloadHandlebarsTemplates } from './helpers/templates.mjs';
 import { MY_RPG } from './helpers/config.mjs';
@@ -15,7 +17,8 @@ Hooks.once('init', function () {
   // Add utility classes to the global game object so that they're more easily
   // accessible in global contexts.
   game.myrpg = {
-    myrpgActor
+    myrpgActor,
+    myrpgItem
   };
 
   // Add custom constants for configuration.
@@ -43,6 +46,7 @@ Hooks.once('init', function () {
 
   // Define custom Document classes
   CONFIG.Actor.documentClass = myrpgActor;
+  CONFIG.Item.documentClass = myrpgItem;
 
   // systems/myrpg/myrpg.mjs  — в хуке init
   CONFIG.Combat.initiative = {
@@ -57,6 +61,13 @@ Hooks.once('init', function () {
     makeDefault: true,
     label: 'MY_RPG.SheetLabels.Actor'
   });
+  Items.unregisterSheet('core', ItemSheet);
+  Items.registerSheet('myrpg', myrpgItemSheet, {
+    makeDefault: true,
+    label: 'MY_RPG.SheetLabels.Item',
+    types: ['ability', 'mod', 'armor', 'weapon', 'gear']
+  });
+  console.debug('[MyRPG] Item sheets ready');
 
   // Preload Handlebars templates.
   return preloadHandlebarsTemplates();

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -1,0 +1,30 @@
+export class myrpgItemSheet extends ItemSheet {
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ['myrpg', 'sheet', 'item'],
+      width: 520,
+      height: 'auto'
+    });
+  }
+
+  get itemDocument() {
+    return this.item ?? this.document;
+  }
+
+  get template() {
+    return `systems/myrpg/templates/item/${this.itemDocument.type}-sheet.hbs`;
+  }
+
+  async getData(options = {}) {
+    const context = await super.getData(options);
+    const item = this.itemDocument;
+    context.item = item;
+    context.config = CONFIG.MY_RPG ?? {};
+    context.system = item.system ?? {};
+    context.sheetTitle = game.i18n.localize(`MY_RPG.Item.SheetTitle.${item.type}`);
+    context.myrpg = {
+      bonuses: context.system.bonuses ?? {}
+    };
+    return context;
+  }
+}

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.295",
+  "version": "2.296",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/template.json
+++ b/template.json
@@ -185,5 +185,53 @@
       },
       "attributes": {}
     }
+  },
+  "Item": {
+    "types": ["ability", "mod", "armor", "weapon", "gear"],
+    "templates": {
+      "base": {
+        "description": "",
+        "notes": "",
+        "equipped": false,
+        "quantity": 1,
+        "bonuses": {
+          "physical": 0,
+          "arcane": 0,
+          "mental": 0,
+          "shield": 0,
+          "speed": 0,
+          "attack": 0
+        }
+      }
+    },
+    "ability": {
+      "templates": ["base"],
+      "rank": "",
+      "cost": "",
+      "effect": ""
+    },
+    "mod": {
+      "templates": ["base"],
+      "slot": "",
+      "effect": ""
+    },
+    "armor": {
+      "templates": ["base"],
+      "category": "",
+      "coverage": ""
+    },
+    "weapon": {
+      "templates": ["base"],
+      "skill": "",
+      "damage": "",
+      "range": "",
+      "properties": ""
+    },
+    "gear": {
+      "templates": ["base"],
+      "uses": "",
+      "weight": "",
+      "rarity": ""
+    }
   }
 }

--- a/templates/item/ability-sheet.hbs
+++ b/templates/item/ability-sheet.hbs
@@ -1,0 +1,83 @@
+<form class="myrpg-item-sheet {{cssClass}}" autocomplete="off">
+  <header class="sheet-header myrpg-item-header">
+    <h1 class="item-title">
+      <input
+        type="text"
+        name="name"
+        value="{{item.name}}"
+        placeholder="{{localize 'MY_RPG.Item.General.NamePlaceholder'}}"
+      />
+    </h1>
+    <div class="item-meta-grid">
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.General.Quantity'}}</label>
+        <input type="number" name="system.quantity" value="{{system.quantity}}" min="0" />
+      </div>
+      <div class="form-group checkbox">
+        <label>
+          <input type="checkbox" name="system.equipped" {{checked system.equipped}} />
+          {{localize 'MY_RPG.Item.General.Equipped'}}
+        </label>
+      </div>
+    </div>
+  </header>
+
+  <section class="sheet-body myrpg-item-body">
+    <h2 class="section-title">{{sheetTitle}}</h2>
+    <div class="item-section">
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.Ability.Rank'}}</label>
+        <input type="text" name="system.rank" value="{{system.rank}}" />
+      </div>
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.Ability.Cost'}}</label>
+        <input type="text" name="system.cost" value="{{system.cost}}" />
+      </div>
+    </div>
+
+    <div class="item-section">
+      <label>{{localize 'MY_RPG.Item.Ability.Effect'}}</label>
+      <textarea name="system.effect" rows="4">{{system.effect}}</textarea>
+    </div>
+
+    <div class="item-section">
+      <label>{{localize 'MY_RPG.Item.General.Description'}}</label>
+      <textarea name="system.description" rows="4">{{system.description}}</textarea>
+    </div>
+
+    <div class="item-section">
+      <label>{{localize 'MY_RPG.Item.General.Notes'}}</label>
+      <textarea name="system.notes" rows="3">{{system.notes}}</textarea>
+    </div>
+
+    <div class="item-section">
+      <h3>{{localize 'MY_RPG.Item.Bonuses.Section'}}</h3>
+      <div class="myrpg-item-bonuses-grid">
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Physical'}}
+          <input type="number" name="system.bonuses.physical" value="{{system.bonuses.physical}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Arcane'}}
+          <input type="number" name="system.bonuses.arcane" value="{{system.bonuses.arcane}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Mental'}}
+          <input type="number" name="system.bonuses.mental" value="{{system.bonuses.mental}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Shield'}}
+          <input type="number" name="system.bonuses.shield" value="{{system.bonuses.shield}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Speed'}}
+          <input type="number" name="system.bonuses.speed" value="{{system.bonuses.speed}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Attack'}}
+          <input type="number" name="system.bonuses.attack" value="{{system.bonuses.attack}}" />
+        </label>
+      </div>
+    </div>
+  </section>
+</form>

--- a/templates/item/armor-sheet.hbs
+++ b/templates/item/armor-sheet.hbs
@@ -1,0 +1,75 @@
+<form class="myrpg-item-sheet {{cssClass}}" autocomplete="off">
+  <header class="sheet-header myrpg-item-header">
+    <h1 class="item-title">
+      <input
+        type="text"
+        name="name"
+        value="{{item.name}}"
+        placeholder="{{localize 'MY_RPG.Item.General.NamePlaceholder'}}"
+      />
+    </h1>
+    <div class="item-meta-grid">
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.General.Quantity'}}</label>
+        <input type="number" name="system.quantity" value="{{system.quantity}}" min="0" />
+      </div>
+      <div class="form-group checkbox">
+        <label>
+          <input type="checkbox" name="system.equipped" {{checked system.equipped}} />
+          {{localize 'MY_RPG.Item.General.Equipped'}}
+        </label>
+      </div>
+    </div>
+  </header>
+
+  <section class="sheet-body myrpg-item-body">
+    <h2 class="section-title">{{sheetTitle}}</h2>
+
+    <div class="item-section">
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.Armor.Category'}}</label>
+        <input type="text" name="system.category" value="{{system.category}}" />
+      </div>
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.Armor.Coverage'}}</label>
+        <input type="text" name="system.coverage" value="{{system.coverage}}" />
+      </div>
+    </div>
+
+    <div class="item-section">
+      <label>{{localize 'MY_RPG.Item.General.Description'}}</label>
+      <textarea name="system.description" rows="4">{{system.description}}</textarea>
+    </div>
+
+    <div class="item-section">
+      <h3>{{localize 'MY_RPG.Item.Bonuses.Section'}}</h3>
+      <div class="myrpg-item-bonuses-grid">
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Physical'}}
+          <input type="number" name="system.bonuses.physical" value="{{system.bonuses.physical}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Arcane'}}
+          <input type="number" name="system.bonuses.arcane" value="{{system.bonuses.arcane}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Mental'}}
+          <input type="number" name="system.bonuses.mental" value="{{system.bonuses.mental}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Shield'}}
+          <input type="number" name="system.bonuses.shield" value="{{system.bonuses.shield}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Speed'}}
+          <input type="number" name="system.bonuses.speed" value="{{system.bonuses.speed}}" />
+        </label>
+      </div>
+    </div>
+
+    <div class="item-section">
+      <label>{{localize 'MY_RPG.Item.General.Notes'}}</label>
+      <textarea name="system.notes" rows="3">{{system.notes}}</textarea>
+    </div>
+  </section>
+</form>

--- a/templates/item/gear-sheet.hbs
+++ b/templates/item/gear-sheet.hbs
@@ -1,0 +1,79 @@
+<form class="myrpg-item-sheet {{cssClass}}" autocomplete="off">
+  <header class="sheet-header myrpg-item-header">
+    <h1 class="item-title">
+      <input
+        type="text"
+        name="name"
+        value="{{item.name}}"
+        placeholder="{{localize 'MY_RPG.Item.General.NamePlaceholder'}}"
+      />
+    </h1>
+    <div class="item-meta-grid">
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.General.Quantity'}}</label>
+        <input type="number" name="system.quantity" value="{{system.quantity}}" min="0" />
+      </div>
+      <div class="form-group checkbox">
+        <label>
+          <input type="checkbox" name="system.equipped" {{checked system.equipped}} />
+          {{localize 'MY_RPG.Item.General.Equipped'}}
+        </label>
+      </div>
+    </div>
+  </header>
+
+  <section class="sheet-body myrpg-item-body">
+    <h2 class="section-title">{{sheetTitle}}</h2>
+
+    <div class="item-section">
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.Gear.Uses'}}</label>
+        <input type="text" name="system.uses" value="{{system.uses}}" />
+      </div>
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.Gear.Weight'}}</label>
+        <input type="text" name="system.weight" value="{{system.weight}}" />
+      </div>
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.Gear.Rarity'}}</label>
+        <input type="text" name="system.rarity" value="{{system.rarity}}" />
+      </div>
+    </div>
+
+    <div class="item-section">
+      <label>{{localize 'MY_RPG.Item.General.Description'}}</label>
+      <textarea name="system.description" rows="4">{{system.description}}</textarea>
+    </div>
+
+    <div class="item-section">
+      <label>{{localize 'MY_RPG.Item.General.Notes'}}</label>
+      <textarea name="system.notes" rows="3">{{system.notes}}</textarea>
+    </div>
+
+    <div class="item-section">
+      <h3>{{localize 'MY_RPG.Item.Bonuses.Section'}}</h3>
+      <div class="myrpg-item-bonuses-grid">
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Physical'}}
+          <input type="number" name="system.bonuses.physical" value="{{system.bonuses.physical}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Arcane'}}
+          <input type="number" name="system.bonuses.arcane" value="{{system.bonuses.arcane}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Mental'}}
+          <input type="number" name="system.bonuses.mental" value="{{system.bonuses.mental}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Speed'}}
+          <input type="number" name="system.bonuses.speed" value="{{system.bonuses.speed}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Attack'}}
+          <input type="number" name="system.bonuses.attack" value="{{system.bonuses.attack}}" />
+        </label>
+      </div>
+    </div>
+  </section>
+</form>

--- a/templates/item/mod-sheet.hbs
+++ b/templates/item/mod-sheet.hbs
@@ -1,0 +1,80 @@
+<form class="myrpg-item-sheet {{cssClass}}" autocomplete="off">
+  <header class="sheet-header myrpg-item-header">
+    <h1 class="item-title">
+      <input
+        type="text"
+        name="name"
+        value="{{item.name}}"
+        placeholder="{{localize 'MY_RPG.Item.General.NamePlaceholder'}}"
+      />
+    </h1>
+    <div class="item-meta-grid">
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.General.Quantity'}}</label>
+        <input type="number" name="system.quantity" value="{{system.quantity}}" min="0" />
+      </div>
+      <div class="form-group checkbox">
+        <label>
+          <input type="checkbox" name="system.equipped" {{checked system.equipped}} />
+          {{localize 'MY_RPG.Item.General.Equipped'}}
+        </label>
+      </div>
+    </div>
+  </header>
+
+  <section class="sheet-body myrpg-item-body">
+    <h2 class="section-title">{{sheetTitle}}</h2>
+
+    <div class="item-section">
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.Mod.Slot'}}</label>
+        <input type="text" name="system.slot" value="{{system.slot}}" />
+      </div>
+    </div>
+
+    <div class="item-section">
+      <label>{{localize 'MY_RPG.Item.Mod.Effect'}}</label>
+      <textarea name="system.effect" rows="4">{{system.effect}}</textarea>
+    </div>
+
+    <div class="item-section">
+      <label>{{localize 'MY_RPG.Item.General.Description'}}</label>
+      <textarea name="system.description" rows="4">{{system.description}}</textarea>
+    </div>
+
+    <div class="item-section">
+      <label>{{localize 'MY_RPG.Item.General.Notes'}}</label>
+      <textarea name="system.notes" rows="3">{{system.notes}}</textarea>
+    </div>
+
+    <div class="item-section">
+      <h3>{{localize 'MY_RPG.Item.Bonuses.Section'}}</h3>
+      <div class="myrpg-item-bonuses-grid">
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Physical'}}
+          <input type="number" name="system.bonuses.physical" value="{{system.bonuses.physical}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Arcane'}}
+          <input type="number" name="system.bonuses.arcane" value="{{system.bonuses.arcane}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Mental'}}
+          <input type="number" name="system.bonuses.mental" value="{{system.bonuses.mental}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Shield'}}
+          <input type="number" name="system.bonuses.shield" value="{{system.bonuses.shield}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Speed'}}
+          <input type="number" name="system.bonuses.speed" value="{{system.bonuses.speed}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Attack'}}
+          <input type="number" name="system.bonuses.attack" value="{{system.bonuses.attack}}" />
+        </label>
+      </div>
+    </div>
+  </section>
+</form>

--- a/templates/item/weapon-sheet.hbs
+++ b/templates/item/weapon-sheet.hbs
@@ -1,0 +1,82 @@
+<form class="myrpg-item-sheet {{cssClass}}" autocomplete="off">
+  <header class="sheet-header myrpg-item-header">
+    <h1 class="item-title">
+      <input
+        type="text"
+        name="name"
+        value="{{item.name}}"
+        placeholder="{{localize 'MY_RPG.Item.General.NamePlaceholder'}}"
+      />
+    </h1>
+    <div class="item-meta-grid">
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.General.Quantity'}}</label>
+        <input type="number" name="system.quantity" value="{{system.quantity}}" min="0" />
+      </div>
+      <div class="form-group checkbox">
+        <label>
+          <input type="checkbox" name="system.equipped" {{checked system.equipped}} />
+          {{localize 'MY_RPG.Item.General.Equipped'}}
+        </label>
+      </div>
+    </div>
+  </header>
+
+  <section class="sheet-body myrpg-item-body">
+    <h2 class="section-title">{{sheetTitle}}</h2>
+
+    <div class="item-section">
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.Weapon.Skill'}}</label>
+        <input type="text" name="system.skill" value="{{system.skill}}" />
+      </div>
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.Weapon.Damage'}}</label>
+        <input type="text" name="system.damage" value="{{system.damage}}" />
+      </div>
+    </div>
+
+    <div class="item-section">
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.Weapon.Range'}}</label>
+        <input type="text" name="system.range" value="{{system.range}}" />
+      </div>
+      <div class="form-group">
+        <label>{{localize 'MY_RPG.Item.Weapon.Properties'}}</label>
+        <input type="text" name="system.properties" value="{{system.properties}}" />
+      </div>
+    </div>
+
+    <div class="item-section">
+      <label>{{localize 'MY_RPG.Item.General.Description'}}</label>
+      <textarea name="system.description" rows="4">{{system.description}}</textarea>
+    </div>
+
+    <div class="item-section">
+      <h3>{{localize 'MY_RPG.Item.Bonuses.Section'}}</h3>
+      <div class="myrpg-item-bonuses-grid">
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Attack'}}
+          <input type="number" name="system.bonuses.attack" value="{{system.bonuses.attack}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Physical'}}
+          <input type="number" name="system.bonuses.physical" value="{{system.bonuses.physical}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Arcane'}}
+          <input type="number" name="system.bonuses.arcane" value="{{system.bonuses.arcane}}" />
+        </label>
+        <label>
+          {{localize 'MY_RPG.Item.Bonuses.Mental'}}
+          <input type="number" name="system.bonuses.mental" value="{{system.bonuses.mental}}" />
+        </label>
+      </div>
+    </div>
+
+    <div class="item-section">
+      <label>{{localize 'MY_RPG.Item.General.Notes'}}</label>
+      <textarea name="system.notes" rows="3">{{system.notes}}</textarea>
+    </div>
+  </section>
+</form>


### PR DESCRIPTION
## Summary
- introduce a custom Item document with default data and debug logging, plus a dedicated item sheet
- register the item document and sheet, preload new templates, and style the item UI
- expand system templates, localisations, and version metadata for new item types

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ff414d5cf8832ea87de714cba52ba4