### PR TITLE
feat: derive actor stats from embedded items

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1610,13 +1610,10 @@ export class myrpgActorSheet extends ActorSheet {
 
   _getEquippedWeaponBonus(skillKey) {
     if (!skillKey) return 0;
-    const list = this.actor.system.weaponList;
-    const items = Array.isArray(list) ? list : Object.values(list || {});
-    return items.reduce((total, weapon) => {
-      if (!weapon || !weapon.equipped) return total;
-      if ((weapon.skill || '') !== skillKey) return total;
-      return total + this._normalizeWeaponBonus(weapon.skillBonus);
-    }, 0);
+    const bonuses =
+      this.actor.system?.cache?.itemTotals?.weapons?.skillBonuses ?? {};
+    const total = bonuses?.[skillKey];
+    return this._normalizeWeaponBonus(total);
   }
 
   _weaponSkillLabel(skillKey) {

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.297",
+  "version": "2.298",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
## Summary
- compute armor and weapon totals from embedded items and cache them on the actor
- recalculate derived defenses, speed, and rolls using the cached equipment totals
- add prepareDerivedData debug logging and bump the system manifest version to 2.298

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ff51146f28832e96a825e230ff1410