### PR TITLE
feat: redesign actor sheet item handling

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -925,3 +925,185 @@ input.rank5 {
   font-weight: bold;
   margin: 0 0.2em;
 }
+
+.myrpg .item-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.myrpg .item-group {
+  border: 1px solid #d4cbc0;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.65);
+  padding: 0.75rem;
+}
+
+.myrpg .item-group__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.myrpg .item-group__header h3 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.myrpg .item-group__capacity {
+  font-size: 0.9rem;
+  color: #5c5244;
+}
+
+.myrpg .item-group__title i,
+.myrpg .item-group__header i {
+  color: #7a6754;
+}
+
+.myrpg .item-create.item-control {
+  border: none;
+  background: none;
+  color: inherit;
+  padding: 0.25rem;
+  cursor: pointer;
+}
+
+.myrpg .item-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.myrpg .item-row {
+  border: 1px solid #d4cbc0;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 0.5rem 0.75rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.myrpg .item-row--equipped {
+  border-color: #3f8854;
+  box-shadow: 0 0 0 1px rgba(63, 136, 84, 0.25);
+}
+
+.myrpg .item-row__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.myrpg .item-row__name {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  flex: 1 1 auto;
+}
+
+.myrpg .item-row__name img {
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  object-fit: cover;
+}
+
+.myrpg .item-row__badges {
+  list-style: none;
+  display: flex;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  flex-wrap: wrap;
+}
+
+.myrpg .item-badge {
+  background: rgba(112, 95, 80, 0.14);
+  border-radius: 999px;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.85rem;
+  color: #4d4034;
+}
+
+.myrpg .item-row__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-left: auto;
+}
+
+.myrpg .item-control {
+  border: none;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+.myrpg .item-control:hover,
+.myrpg .item-control:focus {
+  color: #1d6ea8;
+}
+
+.myrpg .item-quantity-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: 1px solid #d4cbc0;
+  border-radius: 4px;
+  padding: 0.15rem 0.35rem;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.myrpg .item-quantity-control .item-quantity-step {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0;
+  color: inherit;
+}
+
+.myrpg .item-quantity-value {
+  min-width: 1.5rem;
+  text-align: center;
+  font-weight: 600;
+}
+
+.myrpg .item-equip-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.myrpg .item-row__summary {
+  margin-top: 0.5rem;
+  font-size: 0.95rem;
+  color: #3f3327;
+}
+
+.myrpg .item-group__empty {
+  margin: 0.5rem 0 0;
+  font-style: italic;
+  color: #6b5b4d;
+}
+
+.myrpg .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -222,17 +222,14 @@
     "Skill": {
       "Liderstvo": "Leadership",
       "Obman": "Deception",
-
       "Akrobatika": "Acrobatics",
       "Skrytost": "Stealth",
       "Strelba": "Shooting",
       "Upravlenie_transportom": "Vehicle Handling",
       "Lovkost_ruk": "Sleight of Hand",
       "Blizhniy_boy": "Melee",
-
       "Atletika": "Athletics",
       "Zapugivanie": "Intimidation",
-
       "Analiz": "Analysis",
       "Tekhnika": "Technology",
       "Priroda": "Nature",
@@ -243,7 +240,6 @@
       "Znanie_azura": "Azure Studies",
       "Manipulatsiya": "Manipulation",
       "Diplomatiya": "Diplomacy",
-
       "Artefaktorika": "Artificing",
       "Biomantia": "Biomancy",
       "Stitiyannost": "Elementalism",
@@ -294,6 +290,44 @@
       "Upgrade2": "Upgrade 2",
       "AddRow": "Add Row",
       "Rank": "Rank"
+    },
+    "ItemGroups": {
+      "Abilities": "Abilities",
+      "EmptyAbilities": "No abilities yet.",
+      "CreateAbility": "Add ability",
+      "NewAbility": "New Ability",
+      "Mods": "Mods",
+      "EmptyMods": "No mods yet.",
+      "CreateMod": "Add mod",
+      "NewMod": "New Mod",
+      "Weapons": "Weapons & Tools",
+      "EmptyWeapons": "No weapons yet.",
+      "CreateWeapon": "Add weapon or tool",
+      "NewWeapon": "New Weapon",
+      "Armor": "Armor",
+      "EmptyArmor": "No armor yet.",
+      "CreateArmor": "Add armor",
+      "NewArmor": "New Armor",
+      "Gear": "Gear",
+      "EmptyGear": "No gear yet.",
+      "CreateGear": "Add gear",
+      "NewGear": "New Gear",
+      "Unnamed": "Unnamed item"
+    },
+    "ItemControls": {
+      "Edit": "Edit",
+      "Delete": "Delete",
+      "Chat": "Send to chat",
+      "Equip": "Equipped",
+      "EquipAria": "Toggle equipped state",
+      "Quantity": "Quantity",
+      "QuantityIncrease": "Increase quantity",
+      "QuantityDecrease": "Decrease quantity",
+      "NewItemFallback": "New {type}"
+    },
+    "ItemDialogs": {
+      "DeleteTitle": "Delete {type}",
+      "DeleteContent": "Are you sure you want to delete {name}? This action cannot be undone."
     }
   },
   "TYPES": {

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -297,6 +297,44 @@
       "Upgrade2": "Улучшение 2",
       "AddRow": "Добавить строку",
       "Rank": "Ранг"
+    },
+    "ItemGroups": {
+      "Abilities": "Способности",
+      "EmptyAbilities": "Пока нет способностей.",
+      "CreateAbility": "Добавить способность",
+      "NewAbility": "Новая способность",
+      "Mods": "Модификации",
+      "EmptyMods": "Пока нет модификаций.",
+      "CreateMod": "Добавить модификацию",
+      "NewMod": "Новая модификация",
+      "Weapons": "Оружие и инструменты",
+      "EmptyWeapons": "Пока нет оружия.",
+      "CreateWeapon": "Добавить оружие или инструмент",
+      "NewWeapon": "Новое оружие",
+      "Armor": "Броня",
+      "EmptyArmor": "Пока нет брони.",
+      "CreateArmor": "Добавить броню",
+      "NewArmor": "Новая броня",
+      "Gear": "Снаряжение",
+      "EmptyGear": "Пока нет снаряжения.",
+      "CreateGear": "Добавить снаряжение",
+      "NewGear": "Новое снаряжение",
+      "Unnamed": "Безымянный предмет"
+    },
+    "ItemControls": {
+      "Edit": "Изменить",
+      "Delete": "Удалить",
+      "Chat": "Отправить в чат",
+      "Equip": "Снаряжено",
+      "EquipAria": "Переключить статус экипировки",
+      "Quantity": "Количество",
+      "QuantityIncrease": "Увеличить количество",
+      "QuantityDecrease": "Уменьшить количество",
+      "NewItemFallback": "Новый {type}"
+    },
+    "ItemDialogs": {
+      "DeleteTitle": "Удалить {type}",
+      "DeleteContent": "Вы уверены, что хотите удалить {name}? Это действие нельзя отменить."
     }
   },
   "TYPES": {

--- a/system.json
+++ b/system.json
@@ -16,17 +16,21 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.298",
+  "version": "2.299",
   "compatibility": {
     "minimum": "12",
     "verified": "12"
   },
-  "esmodules": ["module/myrpg.mjs"],
-  "styles": ["css/myrpg.css"],
+  "esmodules": [
+    "module/myrpg.mjs"
+  ],
+  "styles": [
+    "css/myrpg.css"
+  ],
   "languages": [
     {
       "lang": "ru",
-      "name": "Русский",
+      "name": "\u0420\u0443\u0441\u0441\u043a\u0438\u0439",
       "path": "lang/ru.json"
     },
     {
@@ -43,7 +47,7 @@
   "background": "systems/myrpg/assets/anvil-impact.png",
   "grid": {
     "distance": 2,
-    "units": "м"
+    "units": "\u043c"
   },
   "primaryTokenAttribute": {
     "attribute": "system.stress.value",

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -393,318 +393,218 @@
         {{#ifUnity}}
         <div class='rune-size'>
           <label>{{localize 'MY_RPG.RunesTable.SizeLabel'}}</label>
-          <input type='number' value='{{system.abilitiesList.length}}' disabled />
+          <input type='number' value='{{abilityCount}}' disabled />
           <span class='divider'>/</span>
           <input type='number' value='{{runeMax}}' disabled />
         </div>
         {{/ifUnity}}
-        <section class='abilities-section'>
-          <table class='abilities-table{{#ifUnity}} abilities-table--unity{{/ifUnity}}'>
-            <thead>
-              <tr>
-                <th class='col-name primary-header'>{{localize (worldChoice 'MY_RPG.RunesTable.PrimaryHeader' 'MY_RPG.AbilitiesTable.PrimaryHeader')}}</th>
-                <th class='col-rank'>{{localize 'MY_RPG.AbilitiesTable.Rank'}}</th>
-                {{#ifUnity}}
-                <th class='col-type'>{{localize 'MY_RPG.RunesTable.RuneType'}}</th>
-                {{/ifUnity}}
-                <th class='col-upg1'>{{localize 'MY_RPG.AbilitiesTable.Upgrade1'}}</th>
-                <th class='col-upg2'>{{localize 'MY_RPG.AbilitiesTable.Upgrade2'}}</th>
-                <th class='col-delete'>
-                  <a class='abilities-add-row' title='{{localize "MY_RPG.AbilitiesTable.AddRow"}}'>
-                    <i class='fa-solid fa-plus'></i>
-                  </a>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {{#each system.abilitiesList as |row i|}}
-                <tr class='ability-row' data-index='{{i}}'>
-                  <td class='col-name'>{{{row.name}}}</td>
-                  <td class='col-rank'>{{rankLabel row.rank}}</td>
-                  {{#ifUnity}}
-                  <td class='col-type'>{{localize (concat 'MY_RPG.RuneTypes.' row.runeType)}}</td>
-                  {{/ifUnity}}
-                  <td class='col-upg1'>{{localize (concat 'MY_RPG.AbilityUpgrades.' row.upgrade1)}}</td>
-                  <td class='col-upg2'>{{localize (concat 'MY_RPG.AbilityUpgrades.' row.upgrade2)}}</td>
-                  <td class='col-delete'>
-                    <a
-                      class='abilities-chat-row'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.SendToChat"}}'
+        <section class='item-groups' data-groups='abilities'>
+          {{#each (lookup itemGroups 'abilities') as |group|}}
+            <section class='item-group' data-item-group='{{group.key}}'>
+              <header class='item-group__header'>
+                <h3>
+                  {{#if group.icon}}<i class='{{group.icon}}'></i>{{/if}}
+                  <span class='item-group__title'>{{group.label}}</span>
+                  {{#if group.capacity}}
+                    <span class='item-group__capacity'>{{group.capacity.value}} / {{group.capacity.max}}</span>
+                  {{/if}}
+                </h3>
+                <button
+                  type='button'
+                  class='item-create item-control'
+                  data-type='{{group.type}}'
+                  data-group-key='{{group.key}}'
+                  title='{{group.createLabel}}'
+                >
+                  <i class='fa-solid fa-plus'></i>
+                  <span class='sr-only'>{{group.createLabel}}</span>
+                </button>
+              </header>
+              {{#if group.items.length}}
+                <ol class='item-list'>
+                  {{#each group.items as |item|}}
+                    <li
+                      class='item-row {{#if item.equipped}}item-row--equipped{{/if}}'
+                      data-item-id='{{item.id}}'
+                      data-group-key='{{item.groupKey}}'
                     >
-                      <i class='fa-solid fa-comment-dots'></i>
-                    </a>
-                    <a
-                      class='abilities-edit-row'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.AbilityConfig.Title"}}'
-                    >
-                      <i class='fa-solid fa-pen'></i>
-                    </a>
-                    <a
-                      class='abilities-remove-row'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.Dialog.ConfirmDeleteTitle"}}'
-                    >
-                      <i class='fa-solid fa-trash'></i>
-                    </a>
-                  </td>
-                </tr>
-                <tr class='ability-effect-row'>
-                  <td class='col-effect' colspan='{{#ifUnity}}6{{else}}5{{/ifUnity}}'>
-                    <div class='effect-wrapper'>{{{row.effect}}}</div>
-                  </td>
-                </tr>
-              {{/each}}
-            </tbody>
-          </table>
-        </section>
-        <section class='mods-section'>
-          <table class='abilities-table mods-table'>
-            <thead>
-              <tr>
-                <th class='col-name primary-header'>{{localize 'MY_RPG.ModsTable.PrimaryHeader'}}</th>
-                <th class='col-rank'>{{localize 'MY_RPG.ModsTable.Rank'}}</th>
-                <th class='col-upg1'>{{localize 'MY_RPG.ModsTable.Upgrade1'}}</th>
-                <th class='col-upg2'>{{localize 'MY_RPG.ModsTable.Upgrade2'}}</th>
-                <th class='col-delete'>
-                  <a class='mods-add-row' title='{{localize "MY_RPG.ModsTable.AddRow"}}'>
-                    <i class='fa-solid fa-plus'></i>
-                  </a>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {{#each system.modsList as |row i|}}
-                <tr class='mod-row' data-index='{{i}}'>
-                  <td class='col-name'>{{{row.name}}}</td>
-                  <td class='col-rank'>{{rankLabel row.rank}}</td>
-                <td class='col-upg1'>{{localize (concat 'MY_RPG.AbilityUpgrades.' row.upgrade1)}}</td>
-                <td class='col-upg2'>{{localize (concat 'MY_RPG.AbilityUpgrades.' row.upgrade2)}}</td>
-                <td class='col-delete'>
-                    <a
-                      class='mods-chat-row'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.SendToChat"}}'
-                    >
-                      <i class='fa-solid fa-comment-dots'></i>
-                    </a>
-                    <a
-                      class='mods-edit-row'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.AbilityConfig.Title"}}'
-                    >
-                      <i class='fa-solid fa-pen'></i>
-                    </a>
-                    <a
-                      class='mods-remove-row'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.Dialog.ConfirmDeleteTitle"}}'
-                    >
-                      <i class='fa-solid fa-trash'></i>
-                    </a>
-                  </td>
-                </tr>
-                <tr class='mod-effect-row'>
-                  <td class='col-effect' colspan='5'>
-                    <div class='effect-wrapper'>{{{row.effect}}}</div>
-                  </td>
-                </tr>
-              {{/each}}
-            </tbody>
-          </table>
+                      <div class='item-row__header'>
+                        <div class='item-row__name'>
+                          <img src='{{item.img}}' alt='' />
+                          <span class='item-row__label'>{{item.name}}</span>
+                        </div>
+                        {{#if item.hasBadges}}
+                          <ul class='item-row__badges'>
+                            {{#each item.badges as |badge|}}
+                              <li class='item-badge'>{{badge}}</li>
+                            {{/each}}
+                          </ul>
+                        {{/if}}
+                        <div class='item-row__actions'>
+                          {{#if item.showQuantity}}
+                            <div class='item-quantity-control' aria-label='{{../../itemControls.quantity}}'>
+                              <button
+                                type='button'
+                                class='item-quantity-step'
+                                data-step='-1'
+                                title='{{../../itemControls.quantityDecrease}}'
+                              >
+                                <i class='fa-solid fa-minus'></i>
+                                <span class='sr-only'>{{../../itemControls.quantityDecrease}}</span>
+                              </button>
+                              <span class='item-quantity-value'>{{item.quantity}}</span>
+                              <button
+                                type='button'
+                                class='item-quantity-step'
+                                data-step='1'
+                                title='{{../../itemControls.quantityIncrease}}'
+                              >
+                                <i class='fa-solid fa-plus'></i>
+                                <span class='sr-only'>{{../../itemControls.quantityIncrease}}</span>
+                              </button>
+                            </div>
+                          {{/if}}
+                          {{#if item.showEquip}}
+                            <label class='item-equip-toggle' title='{{../../itemControls.equip}}'>
+                              <input
+                                type='checkbox'
+                                class='item-equip-checkbox'
+                                {{#if item.equipped}}checked{{/if}}
+                                aria-label='{{../../itemControls.equipAria}}'
+                              />
+                            </label>
+                          {{/if}}
+                          <button type='button' class='item-chat item-control' title='{{../../itemControls.chat}}'>
+                            <i class='fa-solid fa-comment-dots'></i>
+                            <span class='sr-only'>{{../../itemControls.chat}}</span>
+                          </button>
+                          <button type='button' class='item-edit item-control' title='{{../../itemControls.edit}}'>
+                            <i class='fa-solid fa-pen'></i>
+                            <span class='sr-only'>{{../../itemControls.edit}}</span>
+                          </button>
+                          <button type='button' class='item-delete item-control' title='{{../../itemControls.delete}}'>
+                            <i class='fa-solid fa-trash'></i>
+                            <span class='sr-only'>{{../../itemControls.delete}}</span>
+                          </button>
+                        </div>
+                      </div>
+                      {{#if item.hasSummary}}
+                        <div class='item-row__summary'>
+                          {{{item.summary}}}
+                        </div>
+                      {{/if}}
+                    </li>
+                  {{/each}}
+                </ol>
+              {{else}}
+                <p class='item-group__empty'>{{group.empty}}</p>
+              {{/if}}
+            </section>
+          {{/each}}
         </section>
       </div>
-
       <div class='tab inventory' data-group='primary' data-tab='inventory'>
-        <div class='sheet-box'>
-          <h2>{{localize 'MY_RPG.ArmorItem.ArmorSectionTitle'}}</h2>
-          <table class='abilities-table armor-table'>
-            <thead>
-              <tr>
-                <th class='col-name primary-header'>{{localize 'MY_RPG.ArmorItem.ArmorSectionTitle'}}</th>
-                <th class='col-cost'>{{localize 'MY_RPG.Inventory.Quantity'}}</th>
-                <th class='col-equip'>{{localize 'MY_RPG.ArmorTable.EquippedLabel'}}</th>
-                <th class='col-delete'>
-                  <a class='armor-add-row' title='{{localize "MY_RPG.ArmorTable.AddRow"}}'>
-                    <i class='fa-solid fa-plus'></i>
-                  </a>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {{#each system.armorList as |item i|}}
-                <tr class='armor-row' data-index='{{i}}'>
-                  <td class='col-name'>{{{item.name}}}</td>
-                  <td class='col-cost'>
-                    <a class='armor-quantity-minus' data-index='{{i}}'>
-                      <i class='fa-solid fa-minus'></i>
-                    </a>
-                    <span class='quantity-value'>{{item.quantity}}</span>
-                    <a class='armor-quantity-plus' data-index='{{i}}'>
-                      <i class='fa-solid fa-plus'></i>
-                    </a>
-                  </td>
-                  <td class='col-equip'>
-                    <input type='checkbox' class='armor-equip-checkbox' data-index='{{i}}' {{#if item.equipped}}checked{{/if}} />
-                  </td>
-                  <td class='col-delete'>
-                    <a
-                      class='armor-chat-row'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.SendToChat"}}'
+        <section class='item-groups' data-groups='inventory'>
+          {{#each (lookup itemGroups 'inventory') as |group|}}
+            <section class='item-group' data-item-group='{{group.key}}'>
+              <header class='item-group__header'>
+                <h3>
+                  {{#if group.icon}}<i class='{{group.icon}}'></i>{{/if}}
+                  <span class='item-group__title'>{{group.label}}</span>
+                </h3>
+                <button
+                  type='button'
+                  class='item-create item-control'
+                  data-type='{{group.type}}'
+                  data-group-key='{{group.key}}'
+                  title='{{group.createLabel}}'
+                >
+                  <i class='fa-solid fa-plus'></i>
+                  <span class='sr-only'>{{group.createLabel}}</span>
+                </button>
+              </header>
+              {{#if group.items.length}}
+                <ol class='item-list'>
+                  {{#each group.items as |item|}}
+                    <li
+                      class='item-row {{#if item.equipped}}item-row--equipped{{/if}}'
+                      data-item-id='{{item.id}}'
+                      data-group-key='{{item.groupKey}}'
                     >
-                      <i class='fa-solid fa-comment-dots'></i>
-                    </a>
-                    <a
-                      class='armor-edit-row'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.ArmorTable.EditTitle"}}'
-                    >
-                      <i class='fa-solid fa-pen'></i>
-                    </a>
-                    <a
-                      class='armor-remove-row'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.ArmorTable.ConfirmDeleteTitle"}}'
-                    >
-                      <i class='fa-solid fa-trash'></i>
-                    </a>
-                  </td>
-                </tr>
-                <tr class='armor-effect-row'>
-                  <td class='col-effect' colspan='4'>
-                    <div class='effect-wrapper'>{{{armorEffect item}}}</div>
-                  </td>
-                </tr>
-              {{/each}}
-            </tbody>
-          </table>
-        </div>
-        <div class='sheet-box'>
-          <h2>{{localize 'MY_RPG.WeaponsTable.SectionTitle'}}</h2>
-          <table class='abilities-table weapon-table'>
-            <thead>
-              <tr>
-                <th class='col-name primary-header'>{{localize 'MY_RPG.WeaponsTable.SectionTitle'}}</th>
-                <th class='col-bonus'>{{localize 'MY_RPG.WeaponsTable.BonusLabel'}}</th>
-                <th class='col-skill'>{{localize 'MY_RPG.WeaponsTable.SkillLabel'}}</th>
-                <th class='col-equip'>{{localize 'MY_RPG.WeaponsTable.EquippedLabel'}}</th>
-                <th class='col-delete'>
-                  <a class='weapon-add-row' title='{{localize "MY_RPG.WeaponsTable.AddRow"}}'>
-                    <i class='fa-solid fa-plus'></i>
-                  </a>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {{#each system.weaponList as |weapon i|}}
-                <tr class='weapon-row' data-index='{{i}}'>
-                  <td class='col-name'>{{{weapon.name}}}</td>
-                  <td class='col-bonus'>{{formatWeaponBonus weapon.skillBonus}}</td>
-                  <td class='col-skill'>{{skillLabel weapon.skill}}</td>
-                  <td class='col-equip'>
-                    <input
-                      type='checkbox'
-                      class='weapon-equip-checkbox'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.WeaponsTable.EquippedLabel"}}'
-                      aria-label='{{localize "MY_RPG.WeaponsTable.EquippedLabel"}}'
-                      {{#if weapon.equipped}}checked{{/if}}
-                    />
-                  </td>
-                  <td class='col-delete'>
-                    <a
-                      class='weapon-chat-row'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.SendToChat"}}'
-                    >
-                      <i class='fa-solid fa-comment-dots'></i>
-                    </a>
-                    <a
-                      class='weapon-edit-row'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.WeaponsTable.EditTitle"}}'
-                    >
-                      <i class='fa-solid fa-pen'></i>
-                    </a>
-                    <a
-                      class='weapon-remove-row'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.WeaponsTable.ConfirmDeleteTitle"}}'
-                    >
-                      <i class='fa-solid fa-trash'></i>
-                    </a>
-                  </td>
-                </tr>
-                <tr class='weapon-effect-row'>
-                  <td class='col-effect' colspan='5'>
-                    <div class='effect-wrapper'>{{{weaponEffect weapon}}}</div>
-                  </td>
-                </tr>
-              {{/each}}
-            </tbody>
-          </table>
-        </div>
-        <div class='sheet-box'>
-          <table class='abilities-table'>
-            <thead>
-              <tr>
-                <th class='col-name primary-header'>{{localize 'MY_RPG.Inventory.EquipmentHeader'}}</th>
-                <th class='col-cost'>{{localize 'MY_RPG.Inventory.Quantity'}}</th>
-                <th class='col-delete'>
-                  <a class='inventory-add-row' title='{{localize "MY_RPG.Inventory.AddRow"}}'>
-                    <i class='fa-solid fa-plus'></i>
-                  </a>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {{#each system.inventoryList as |item i|}}
-                <tr class='inventory-row' data-index='{{i}}'>
-                  <td class='col-name'>{{{item.name}}}</td>
-                  <td class='col-cost'>
-                    <a class='inventory-quantity-minus' data-index='{{i}}'>
-                      <i class='fa-solid fa-minus'></i>
-                    </a>
-                    <span class='quantity-value'>{{item.quantity}}</span>
-                    <a class='inventory-quantity-plus' data-index='{{i}}'>
-                      <i class='fa-solid fa-plus'></i>
-                    </a>
-                  </td>
-                  <td class='col-delete'>
-                    <a
-                      class='inventory-chat-row'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.SendToChat"}}'
-                    >
-                      <i class='fa-solid fa-comment-dots'></i>
-                    </a>
-                    <a
-                      class='inventory-edit-row'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.Inventory.EditTitle"}}'
-                    >
-                      <i class='fa-solid fa-pen'></i>
-                    </a>
-                    <a
-                      class='inventory-remove-row'
-                      data-index='{{i}}'
-                      title='{{localize "MY_RPG.Inventory.ConfirmDeleteTitle"}}'
-                    >
-                      <i class='fa-solid fa-trash'></i>
-                    </a>
-                  </td>
-                </tr>
-                <tr class='inventory-effect-row'>
-                  <td class='col-effect' colspan='3'>
-                    <div class='effect-wrapper'>{{{item.desc}}}</div>
-                  </td>
-                </tr>
-              {{/each}}
-            </tbody>
-          </table>
-        </div>
+                      <div class='item-row__header'>
+                        <div class='item-row__name'>
+                          <img src='{{item.img}}' alt='' />
+                          <span class='item-row__label'>{{item.name}}</span>
+                        </div>
+                        {{#if item.hasBadges}}
+                          <ul class='item-row__badges'>
+                            {{#each item.badges as |badge|}}
+                              <li class='item-badge'>{{badge}}</li>
+                            {{/each}}
+                          </ul>
+                        {{/if}}
+                        <div class='item-row__actions'>
+                          {{#if item.showQuantity}}
+                            <div class='item-quantity-control' aria-label='{{../../itemControls.quantity}}'>
+                              <button
+                                type='button'
+                                class='item-quantity-step'
+                                data-step='-1'
+                                title='{{../../itemControls.quantityDecrease}}'
+                              >
+                                <i class='fa-solid fa-minus'></i>
+                                <span class='sr-only'>{{../../itemControls.quantityDecrease}}</span>
+                              </button>
+                              <span class='item-quantity-value'>{{item.quantity}}</span>
+                              <button
+                                type='button'
+                                class='item-quantity-step'
+                                data-step='1'
+                                title='{{../../itemControls.quantityIncrease}}'
+                              >
+                                <i class='fa-solid fa-plus'></i>
+                                <span class='sr-only'>{{../../itemControls.quantityIncrease}}</span>
+                              </button>
+                            </div>
+                          {{/if}}
+                          {{#if item.showEquip}}
+                            <label class='item-equip-toggle' title='{{../../itemControls.equip}}'>
+                              <input
+                                type='checkbox'
+                                class='item-equip-checkbox'
+                                {{#if item.equipped}}checked{{/if}}
+                                aria-label='{{../../itemControls.equipAria}}'
+                              />
+                            </label>
+                          {{/if}}
+                          <button type='button' class='item-chat item-control' title='{{../../itemControls.chat}}'>
+                            <i class='fa-solid fa-comment-dots'></i>
+                            <span class='sr-only'>{{../../itemControls.chat}}</span>
+                          </button>
+                          <button type='button' class='item-edit item-control' title='{{../../itemControls.edit}}'>
+                            <i class='fa-solid fa-pen'></i>
+                            <span class='sr-only'>{{../../itemControls.edit}}</span>
+                          </button>
+                          <button type='button' class='item-delete item-control' title='{{../../itemControls.delete}}'>
+                            <i class='fa-solid fa-trash'></i>
+                            <span class='sr-only'>{{../../itemControls.delete}}</span>
+                          </button>
+                        </div>
+                      </div>
+                      {{#if item.hasSummary}}
+                        <div class='item-row__summary'>
+                          {{{item.summary}}}
+                        </div>
+                      {{/if}}
+                    </li>
+                  {{/each}}
+                </ol>
+              {{else}}
+                <p class='item-group__empty'>{{group.empty}}</p>
+              {{/if}}
+            </section>
+          {{/each}}
+        </section>
         <div class='sheet-box'>
           <h2>{{localize 'MY_RPG.Resources.Title'}}</h2>
           <section class='resources grid grid-2col'>


### PR DESCRIPTION
## Summary
- refactor the actor sheet to build grouped item collections and add new listener helpers with debug logging
- rebuild the character sheet template to render grouped items with inline controls and refreshed styling/localisation
- update styles, locales, and system manifest for the new sheet layout

## Testing
- not run (Foundry environment unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68ff5d6e2104832eb267d0b068407f2b