### PR TITLE
Fix HTML encoding for item actions

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -617,6 +617,19 @@ export class myrpgActorSheet extends ActorSheet {
     }
   }
 
+  _escapeHTML(value) {
+    const text = value ?? '';
+    if (foundry?.utils?.escapeHTML) {
+      return foundry.utils.escapeHTML(text);
+    }
+    if (globalThis.TextEditor?.encodeHTML) {
+      return TextEditor.encodeHTML(text);
+    }
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
   _getDefaultItemName(config) {
     if (config?.newNameKey) {
       return game.i18n.localize(config.newNameKey);
@@ -696,7 +709,7 @@ export class myrpgActorSheet extends ActorSheet {
     }
     const typeLabel = game.i18n.localize(`TYPES.Item.${item.type}`);
     const title = game.i18n.format('MY_RPG.ItemDialogs.DeleteTitle', { type: typeLabel });
-    const safeName = TextEditor.encodeHTML(item.name || typeLabel);
+    const safeName = this._escapeHTML(item.name || typeLabel);
     const content = `<p>${game.i18n.format('MY_RPG.ItemDialogs.DeleteContent', { name: safeName })}</p>`;
     const confirmed = await Dialog.confirm({ title, content });
     if (!confirmed) return;
@@ -733,7 +746,7 @@ export class myrpgActorSheet extends ActorSheet {
   _buildItemChatContent(item, config) {
     const system = item.system ?? {};
     const lines = [];
-    const name = TextEditor.encodeHTML(item.name || game.i18n.localize(`TYPES.Item.${item.type}`));
+    const name = this._escapeHTML(item.name || game.i18n.localize(`TYPES.Item.${item.type}`));
     lines.push(`<strong>${name}</strong>`);
     const meta = [];
     if (config.showQuantity) {

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.300",
+  "version": "2.301",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
## Summary
- add a helper to safely escape item names for Foundry v12 changes
- update item delete and chat handlers to use the helper
- bump the system version to 2.301

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ff717be8b4832eb86772ac39324b7d