### PR TITLE
Fix item schema to remove deprecated fields and add rank support

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2,10 +2,8 @@ import { debugLog } from '../config.mjs';
 
 const BASE_DEFAULTS = {
   description: '',
-  source: '',
-  quantity: 1,
-  equipped: false,
-  notes: ''
+  rank: '',
+  equipped: false
 };
 
 const TYPE_DEFAULTS = {
@@ -25,6 +23,8 @@ const TYPE_DEFAULTS = {
     upgrade2: 'None'
   },
   armor: {
+    quantity: 1,
+    rank: '',
     itemPhys: 0,
     itemAzure: 0,
     itemMental: 0,
@@ -32,11 +32,14 @@ const TYPE_DEFAULTS = {
     itemSpeed: 0
   },
   weapon: {
+    quantity: 1,
+    rank: '',
     skill: '',
     skillBonus: 0
   },
   gear: {
-    notes: ''
+    quantity: 1,
+    rank: ''
   }
 };
 
@@ -99,10 +102,6 @@ export class MyRPGItem extends Item {
     return String(this.system.description ?? '');
   }
 
-  get source() {
-    return String(this.system.source ?? '');
-  }
-
   get quantity() {
     return Number(this.system.quantity ?? 1);
   }
@@ -163,11 +162,6 @@ export class MyRPGItem extends Item {
       skill: String(skill ?? ''),
       skillBonus: Number(skillBonus ?? 0) || 0
     };
-  }
-
-  get gearNotes() {
-    if (!this.isGear) return undefined;
-    return String(this.system.notes ?? '');
   }
 
   logDebugState(context = 'MyRPGItem state') {

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -583,12 +583,8 @@ export class myrpgActorSheet extends ActorSheet {
         if (speed) badges.push(`${t.localize('MY_RPG.ArmorItem.BonusSpeedLabel')}: ${speed}`);
         break;
       }
-      case 'gear': {
-        if (system.source) {
-          badges.push(`${t.localize('MY_RPG.ItemSheet.Fields.Source')}: ${system.source}`);
-        }
+      case 'gear':
         break;
-      }
       default:
         break;
     }
@@ -606,12 +602,8 @@ export class myrpgActorSheet extends ActorSheet {
         return system.description || '';
       case 'armor':
         return system.description || '';
-      case 'gear': {
-        const parts = [];
-        if (system.description) parts.push(system.description);
-        if (system.notes) parts.push(system.notes);
-        return parts.join('<br><br>');
-      }
+      case 'gear':
+        return system.description || '';
       default:
         return system.description || '';
     }

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -125,6 +125,12 @@ export class MyRPGArmorSheet extends MyRPGItemSheet {
   get template() {
     return 'systems/myrpg/templates/item/armor-sheet.hbs';
   }
+
+  async getData(options) {
+    const data = await super.getData(options);
+    data.rankOptions = buildRankOptions(data.system.rank);
+    return data;
+  }
 }
 
 export class MyRPGWeaponSheet extends MyRPGItemSheet {
@@ -135,6 +141,7 @@ export class MyRPGWeaponSheet extends MyRPGItemSheet {
   async getData(options) {
     const data = await super.getData(options);
     data.skillOptions = buildSkillOptions(data.system.skill);
+    data.rankOptions = buildRankOptions(data.system.rank);
     return data;
   }
 }
@@ -142,5 +149,11 @@ export class MyRPGWeaponSheet extends MyRPGItemSheet {
 export class MyRPGGearSheet extends MyRPGItemSheet {
   get template() {
     return 'systems/myrpg/templates/item/gear-sheet.hbs';
+  }
+
+  async getData(options) {
+    const data = await super.getData(options);
+    data.rankOptions = buildRankOptions(data.system.rank);
+    return data;
   }
 }

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.302",
+  "version": "2.303",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/template.json
+++ b/template.json
@@ -191,10 +191,8 @@
     "templates": {
       "base": {
         "description": "",
-        "source": "",
-        "quantity": 1,
         "equipped": false,
-        "notes": ""
+        "rank": ""
       },
       "rune": {
         "rank": "",
@@ -213,6 +211,8 @@
     },
     "armor": {
       "templates": ["base"],
+      "quantity": 1,
+      "rank": "",
       "itemPhys": 0,
       "itemAzure": 0,
       "itemMental": 0,
@@ -221,12 +221,15 @@
     },
     "weapon": {
       "templates": ["base"],
+      "quantity": 1,
+      "rank": "",
       "skill": "",
       "skillBonus": 0
     },
     "gear": {
       "templates": ["base"],
-      "notes": ""
+      "quantity": 1,
+      "rank": ""
     }
   }
 }

--- a/templates/item/armor-sheet.hbs
+++ b/templates/item/armor-sheet.hbs
@@ -21,13 +21,12 @@
         />
       </div>
       <div class="flexcol">
-        <label>{{localize 'MY_RPG.ItemSheet.Fields.Source'}}</label>
-        <input
-          type="text"
-          name="system.source"
-          value="{{system.source}}"
-          {{#unless editable}}disabled{{/unless}}
-        />
+        <label>{{localize 'MY_RPG.AbilityConfig.Rank'}}</label>
+        <select name="system.rank" {{#unless editable}}disabled{{/unless}}>
+          {{#each rankOptions}}
+            <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+          {{/each}}
+        </select>
       </div>
     </div>
   </header>
@@ -58,14 +57,6 @@
     <div class="form-group">
       <label>{{localize 'MY_RPG.Inventory.Description'}}</label>
       {{editor system.description target="system.description" button=true owner=owner editable=editable}}
-    </div>
-    <div class="form-group">
-      <label>{{localize 'MY_RPG.ItemSheet.Fields.Notes'}}</label>
-      <textarea
-        name="system.notes"
-        rows="4"
-        {{#unless editable}}disabled{{/unless}}
-      >{{system.notes}}</textarea>
     </div>
   </section>
 </form>

--- a/templates/item/cartridge-sheet.hbs
+++ b/templates/item/cartridge-sheet.hbs
@@ -38,15 +38,6 @@
         </div>
       {{/if}}
     </div>
-    <div class="form-group">
-      <label>{{localize 'MY_RPG.ItemSheet.Fields.Source'}}</label>
-      <input
-        type="text"
-        name="system.source"
-        value="{{system.source}}"
-        {{#unless editable}}disabled{{/unless}}
-      />
-    </div>
   </header>
 
   <section class="sheet-body">

--- a/templates/item/gear-sheet.hbs
+++ b/templates/item/gear-sheet.hbs
@@ -21,26 +21,17 @@
         />
       </div>
       <div class="flexcol">
-        <label>{{localize 'MY_RPG.ItemSheet.Fields.Source'}}</label>
-        <input
-          type="text"
-          name="system.source"
-          value="{{system.source}}"
-          {{#unless editable}}disabled{{/unless}}
-        />
+        <label>{{localize 'MY_RPG.AbilityConfig.Rank'}}</label>
+        <select name="system.rank" {{#unless editable}}disabled{{/unless}}>
+          {{#each rankOptions}}
+            <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+          {{/each}}
+        </select>
       </div>
     </div>
   </header>
 
   <section class="sheet-body">
-    <div class="form-group">
-      <label>{{localize 'MY_RPG.ItemSheet.Fields.Notes'}}</label>
-      <textarea
-        name="system.notes"
-        rows="4"
-        {{#unless editable}}disabled{{/unless}}
-      >{{system.notes}}</textarea>
-    </div>
     <div class="form-group">
       <label>{{localize 'MY_RPG.Inventory.Description'}}</label>
       {{editor system.description target="system.description" button=true owner=owner editable=editable}}

--- a/templates/item/implant-sheet.hbs
+++ b/templates/item/implant-sheet.hbs
@@ -28,15 +28,6 @@
         />
       </div>
     </div>
-    <div class="form-group">
-      <label>{{localize 'MY_RPG.ItemSheet.Fields.Source'}}</label>
-      <input
-        type="text"
-        name="system.source"
-        value="{{system.source}}"
-        {{#unless editable}}disabled{{/unless}}
-      />
-    </div>
   </header>
 
   <section class="sheet-body">

--- a/templates/item/weapon-sheet.hbs
+++ b/templates/item/weapon-sheet.hbs
@@ -21,13 +21,12 @@
         />
       </div>
       <div class="flexcol">
-        <label>{{localize 'MY_RPG.ItemSheet.Fields.Source'}}</label>
-        <input
-          type="text"
-          name="system.source"
-          value="{{system.source}}"
-          {{#unless editable}}disabled{{/unless}}
-        />
+        <label>{{localize 'MY_RPG.AbilityConfig.Rank'}}</label>
+        <select name="system.rank" {{#unless editable}}disabled{{/unless}}>
+          {{#each rankOptions}}
+            <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+          {{/each}}
+        </select>
       </div>
     </div>
   </header>
@@ -55,14 +54,6 @@
     <div class="form-group">
       <label>{{localize 'MY_RPG.Inventory.Description'}}</label>
       {{editor system.description target="system.description" button=true owner=owner editable=editable}}
-    </div>
-    <div class="form-group">
-      <label>{{localize 'MY_RPG.ItemSheet.Fields.Notes'}}</label>
-      <textarea
-        name="system.notes"
-        rows="4"
-        {{#unless editable}}disabled{{/unless}}
-      >{{system.notes}}</textarea>
     </div>
   </section>
 </form>


### PR DESCRIPTION
## Summary
- remove the source and notes fields from item defaults and sheets, limiting quantity to equipment only
- add rank defaults and selectors for armor, weapons, and gear
- tidy actor item summaries and bump the system manifest version

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_6905ea785c78832e918d3d6285e90b64