### PR TITLE
Remove cartridge costs and limit inventory stacking

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -10,7 +10,6 @@ const TYPE_DEFAULTS = {
   cartridge: {
     rank: '',
     effect: '',
-    cost: '',
     runeType: 'Spell',
     upgrade1: 'None',
     upgrade2: 'None'
@@ -18,7 +17,6 @@ const TYPE_DEFAULTS = {
   implant: {
     rank: '',
     effect: '',
-    cost: '',
     upgrade1: 'None',
     upgrade2: 'None'
   },
@@ -112,11 +110,10 @@ export class MyRPGItem extends Item {
 
   get cartridgeData() {
     if (!this.isCartridge) return undefined;
-    const { rank = '', effect = '', cost = '', runeType = 'Spell', upgrade1 = 'None', upgrade2 = 'None' } = this.system;
+    const { rank = '', effect = '', runeType = 'Spell', upgrade1 = 'None', upgrade2 = 'None' } = this.system;
     return {
       rank: String(rank ?? ''),
       effect: String(effect ?? ''),
-      cost: String(cost ?? ''),
       runeType: String(runeType ?? 'Spell'),
       upgrade1: String(upgrade1 ?? 'None'),
       upgrade2: String(upgrade2 ?? 'None')
@@ -125,11 +122,10 @@ export class MyRPGItem extends Item {
 
   get implantData() {
     if (!this.isImplant) return undefined;
-    const { rank = '', effect = '', cost = '', upgrade1 = 'None', upgrade2 = 'None' } = this.system;
+    const { rank = '', effect = '', upgrade1 = 'None', upgrade2 = 'None' } = this.system;
     return {
       rank: String(rank ?? ''),
       effect: String(effect ?? ''),
-      cost: String(cost ?? ''),
       upgrade1: String(upgrade1 ?? 'None'),
       upgrade2: String(upgrade2 ?? 'None')
     };

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -43,7 +43,7 @@ const ITEM_GROUP_CONFIG = [
     emptyKey: 'MY_RPG.ItemGroups.EmptyWeapons',
     createKey: 'MY_RPG.ItemGroups.CreateWeapon',
     newNameKey: 'MY_RPG.ItemGroups.NewWeapon',
-    showQuantity: true,
+    showQuantity: false,
     allowEquip: true,
     exclusive: false
   },
@@ -56,7 +56,7 @@ const ITEM_GROUP_CONFIG = [
     emptyKey: 'MY_RPG.ItemGroups.EmptyArmor',
     createKey: 'MY_RPG.ItemGroups.CreateArmor',
     newNameKey: 'MY_RPG.ItemGroups.NewArmor',
-    showQuantity: true,
+    showQuantity: false,
     allowEquip: true,
     exclusive: true
   },
@@ -503,7 +503,7 @@ export class myrpgActorSheet extends ActorSheet {
 
   _prepareItemForDisplay(item, config) {
     const system = item.system ?? {};
-    const quantity = Math.max(Number(system.quantity) || 0, 0);
+    const quantity = config.showQuantity ? Math.max(Number(system.quantity) || 0, 0) : 1;
     const badges = this._getItemBadges(item, config);
     const summary = this._getItemSummary(item, config);
     return {
@@ -538,9 +538,6 @@ export class myrpgActorSheet extends ActorSheet {
           const runeKey = `MY_RPG.RuneTypes.${system.runeType}`;
           badges.push(`${t.localize('MY_RPG.RunesTable.RuneType')}: ${t.localize(runeKey)}`);
         }
-        if (system.cost) {
-          badges.push(`${t.localize('MY_RPG.AbilitiesTable.Cost')}: ${system.cost}`);
-        }
         if (system.upgrade1 && system.upgrade1 !== 'None') {
           badges.push(`${t.localize('MY_RPG.AbilitiesTable.Upgrade1')}: ${t.localize('MY_RPG.AbilityUpgrades.' + system.upgrade1)}`);
         }
@@ -553,9 +550,6 @@ export class myrpgActorSheet extends ActorSheet {
         const rank = Number(system.rank) || 0;
         if (rank) {
           badges.push(`${t.localize('MY_RPG.ModsTable.Rank')}: ${getRankLabel(rank)}`);
-        }
-        if (system.cost) {
-          badges.push(`${t.localize('MY_RPG.ModsTable.Cost')}: ${system.cost}`);
         }
         if (system.upgrade1 && system.upgrade1 !== 'None') {
           badges.push(`${t.localize('MY_RPG.ModsTable.Upgrade1')}: ${t.localize('MY_RPG.AbilityUpgrades.' + system.upgrade1)}`);
@@ -597,7 +591,7 @@ export class myrpgActorSheet extends ActorSheet {
       case 'cartridges':
         return system.effect || system.description || '';
       case 'implants':
-        return system.effect || '';
+        return system.effect || system.description || '';
       case 'weapons':
         return system.description || '';
       case 'armor':
@@ -763,7 +757,7 @@ export class myrpgActorSheet extends ActorSheet {
     const step = Number(event.currentTarget.dataset.step) || 0;
     if (!step) return;
     const { item, $row, config } = this._getItemContextFromEvent(event);
-    if (!item || !$row) return;
+    if (!item || !$row || !config?.showQuantity) return;
     const system = item.system ?? {};
     const current = Math.max(Number(system.quantity) || 0, 0);
     const next = Math.max(current + step, 0);
@@ -862,11 +856,6 @@ export class myrpgActorSheet extends ActorSheet {
     const source = item ?? {};
     const system = source.system ?? source;
     const lines = [];
-    const quantity = Number(system.quantity ?? source.quantity ?? 0);
-    if (quantity)
-      lines.push(
-        `${game.i18n.localize('MY_RPG.Inventory.Quantity')}: ${quantity}`
-      );
     const phys = Number(system.itemPhys) || 0;
     const azure = Number(system.itemAzure) || 0;
     const mental = Number(system.itemMental) || 0;

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.303",
+  "version": "2.304",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/template.json
+++ b/template.json
@@ -197,7 +197,6 @@
       "rune": {
         "rank": "",
         "effect": "",
-        "cost": "",
         "upgrade1": "None",
         "upgrade2": "None"
       }

--- a/templates/item/armor-sheet.hbs
+++ b/templates/item/armor-sheet.hbs
@@ -11,16 +11,6 @@
     </h1>
     <div class="item-meta flexrow">
       <div class="flexcol">
-        <label>{{localize 'MY_RPG.Inventory.Quantity'}}</label>
-        <input
-          type="number"
-          name="system.quantity"
-          value="{{system.quantity}}"
-          min="0"
-          {{#unless editable}}disabled{{/unless}}
-        />
-      </div>
-      <div class="flexcol">
         <label>{{localize 'MY_RPG.AbilityConfig.Rank'}}</label>
         <select name="system.rank" {{#unless editable}}disabled{{/unless}}>
           {{#each rankOptions}}

--- a/templates/item/cartridge-sheet.hbs
+++ b/templates/item/cartridge-sheet.hbs
@@ -18,15 +18,6 @@
           {{/each}}
         </select>
       </div>
-      <div class="flexcol">
-        <label>{{localize 'MY_RPG.AbilityConfig.Cost'}}</label>
-        <input
-          type="number"
-          name="system.cost"
-          value="{{system.cost}}"
-          {{#unless editable}}disabled{{/unless}}
-        />
-      </div>
       {{#if showRuneType}}
         <div class="flexcol">
           <label>{{localize 'MY_RPG.AbilityConfig.RuneType'}}</label>

--- a/templates/item/implant-sheet.hbs
+++ b/templates/item/implant-sheet.hbs
@@ -18,15 +18,6 @@
           {{/each}}
         </select>
       </div>
-      <div class="flexcol">
-        <label>{{localize 'MY_RPG.ModsTable.Cost'}}</label>
-        <input
-          type="number"
-          name="system.cost"
-          value="{{system.cost}}"
-          {{#unless editable}}disabled{{/unless}}
-        />
-      </div>
     </div>
   </header>
 

--- a/templates/item/weapon-sheet.hbs
+++ b/templates/item/weapon-sheet.hbs
@@ -11,16 +11,6 @@
     </h1>
     <div class="item-meta flexrow">
       <div class="flexcol">
-        <label>{{localize 'MY_RPG.Inventory.Quantity'}}</label>
-        <input
-          type="number"
-          name="system.quantity"
-          value="{{system.quantity}}"
-          min="0"
-          {{#unless editable}}disabled{{/unless}}
-        />
-      </div>
-      <div class="flexcol">
         <label>{{localize 'MY_RPG.AbilityConfig.Rank'}}</label>
         <select name="system.rank" {{#unless editable}}disabled{{/unless}}>
           {{#each rankOptions}}


### PR DESCRIPTION
## Summary
- drop the unused cost property from rune-based items and their sheets
- limit quantity controls to gear so weapons and armor remain single items
- surface item descriptions in summaries and bump the system manifest version

## Testing
- not run (not available in repository)

------
https://chatgpt.com/codex/tasks/task_e_6905f22c1878832e9d55122a779d24c8