### PR TITLE
fix: improve item editor styling

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -198,6 +198,24 @@ textarea[disabled] {
   padding-top: 0.5rem;
 }
 
+.myrpg.item-sheet .editor {
+  border: 1px solid #d4cbc0;
+  border-radius: 6px;
+  padding: 0.75rem;
+  background-color: #ffffff;
+  min-height: 120px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.myrpg.item-sheet .editor-content {
+  min-height: 96px;
+  width: 100%;
+}
+
 .center-attributes {
   display: flex;
   flex-direction: column; /* Ставим вертикально */

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.304",
+  "version": "2.305",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/item/armor-sheet.hbs
+++ b/templates/item/armor-sheet.hbs
@@ -44,7 +44,7 @@
         <input type="number" name="system.itemSpeed" value="{{system.itemSpeed}}" {{#unless editable}}disabled{{/unless}} />
       </div>
     </div>
-    <div class="form-group">
+    <div class="form-group rich-text-field">
       <label>{{localize 'MY_RPG.Inventory.Description'}}</label>
       {{editor system.description target="system.description" button=true owner=owner editable=editable}}
     </div>

--- a/templates/item/cartridge-sheet.hbs
+++ b/templates/item/cartridge-sheet.hbs
@@ -32,7 +32,7 @@
   </header>
 
   <section class="sheet-body">
-    <div class="form-group">
+    <div class="form-group rich-text-field">
       <label>{{localize 'MY_RPG.AbilityConfig.Effect'}}</label>
       {{editor system.effect target="system.effect" button=true owner=owner editable=editable}}
     </div>
@@ -54,7 +54,7 @@
         </select>
       </div>
     </div>
-    <div class="form-group">
+    <div class="form-group rich-text-field">
       <label>{{localize 'MY_RPG.Inventory.Description'}}</label>
       {{editor system.description target="system.description" button=true owner=owner editable=editable}}
     </div>

--- a/templates/item/gear-sheet.hbs
+++ b/templates/item/gear-sheet.hbs
@@ -32,7 +32,7 @@
   </header>
 
   <section class="sheet-body">
-    <div class="form-group">
+    <div class="form-group rich-text-field">
       <label>{{localize 'MY_RPG.Inventory.Description'}}</label>
       {{editor system.description target="system.description" button=true owner=owner editable=editable}}
     </div>

--- a/templates/item/implant-sheet.hbs
+++ b/templates/item/implant-sheet.hbs
@@ -22,7 +22,7 @@
   </header>
 
   <section class="sheet-body">
-    <div class="form-group">
+    <div class="form-group rich-text-field">
       <label>{{localize 'MY_RPG.ModsTable.Effect'}}</label>
       {{editor system.effect target="system.effect" button=true owner=owner editable=editable}}
     </div>
@@ -44,7 +44,7 @@
         </select>
       </div>
     </div>
-    <div class="form-group">
+    <div class="form-group rich-text-field">
       <label>{{localize 'MY_RPG.Inventory.Description'}}</label>
       {{editor system.description target="system.description" button=true owner=owner editable=editable}}
     </div>

--- a/templates/item/weapon-sheet.hbs
+++ b/templates/item/weapon-sheet.hbs
@@ -41,7 +41,7 @@
         />
       </div>
     </div>
-    <div class="form-group">
+    <div class="form-group rich-text-field">
       <label>{{localize 'MY_RPG.Inventory.Description'}}</label>
       {{editor system.description target="system.description" button=true owner=owner editable=editable}}
     </div>


### PR DESCRIPTION
## Summary
- style the `{{editor}}` rich-text areas on item sheets with borders, padding, and a minimum height
- tag all item sheet description/effect groups with a shared class so they inherit the new look consistently
- bump the system manifest version to 2.305

## Testing
- not run (manual Foundry rebuild required)


------
https://chatgpt.com/codex/tasks/task_e_6905f7f0eac8832eba6025c486cedf06