### PR TITLE
feat: refresh item sheet layout

### DIFF
--- a/css/myrpg.css
+++ b/css/myrpg.css
@@ -161,29 +161,89 @@ textarea[disabled] {
 }
 
 /* Item sheets ---------------------------------------------------- */
+.myrpg.item-sheet {
+  --item-sheet-border: #d4cbc0;
+  --item-sheet-shadow: rgba(27, 18, 16, 0.12);
+  --item-sheet-label: #3d312d;
+  --item-sheet-heading: #1b1210;
+  --item-sheet-background: #fdf8f2;
+}
+
 .myrpg.item-sheet .sheet-header {
+  display: grid;
+  grid-template-columns: minmax(100px, 132px) 1fr;
+  align-items: center;
+  gap: 1.5rem;
+  padding-bottom: 1.25rem;
+  margin-bottom: 1.25rem;
+  border-bottom: 1px solid var(--item-sheet-border);
+}
+
+.myrpg.item-sheet .item-image {
+  width: 120px;
+  height: 120px;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--item-sheet-border);
+  box-shadow: 0 4px 12px var(--item-sheet-shadow);
+  background-color: #ffffff;
+}
+
+.myrpg.item-sheet .item-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    filter 0.2s ease;
+}
+
+.myrpg.item-sheet .item-image img:hover {
+  transform: scale(1.02);
+  filter: brightness(0.95);
+}
+
+.myrpg.item-sheet .item-details {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
+}
+
+.myrpg.item-sheet .sheet-title {
+  margin: 0;
 }
 
 .myrpg.item-sheet .sheet-title input {
   width: 100%;
-  font-size: 1.25rem;
+  font-size: 1.4rem;
   font-weight: 600;
+  padding: 0.45rem 0.65rem;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  box-shadow: inset 0 0 0 1px var(--item-sheet-border);
+  background-color: #ffffff;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background-color 0.2s ease;
 }
 
-.myrpg.item-sheet .item-meta {
+.myrpg.item-sheet .item-meta-grid {
+  display: grid;
   gap: 1rem;
-  align-items: flex-end;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
-.myrpg.item-sheet .item-meta .flexcol {
-  flex: 1;
+.myrpg.item-sheet .item-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
-.myrpg.item-sheet .form-group {
-  margin-bottom: 0.75rem;
+.myrpg.item-sheet .item-field label {
+  font-weight: 600;
+  color: var(--item-sheet-label);
 }
 
 .myrpg.item-sheet textarea,
@@ -192,15 +252,60 @@ textarea[disabled] {
 .myrpg.item-sheet select {
   width: 100%;
   box-sizing: border-box;
+  padding: 0.45rem 0.6rem;
+  border-radius: 10px;
+  border: 1px solid var(--item-sheet-border);
+  background-color: #ffffff;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.myrpg.item-sheet textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.myrpg.item-sheet input:focus,
+.myrpg.item-sheet select:focus,
+.myrpg.item-sheet textarea:focus {
+  outline: none;
+  border-color: #0896e9;
+  box-shadow: 0 0 0 2px rgba(8, 150, 233, 0.2);
+}
+
+.myrpg.item-sheet .sheet-title input:focus {
+  box-shadow: 0 0 0 2px rgba(8, 150, 233, 0.25);
 }
 
 .myrpg.item-sheet .sheet-body {
-  padding-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding-bottom: 0.5rem;
+}
+
+.myrpg.item-sheet .item-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--item-sheet-border);
+  background: var(--item-sheet-background);
+  box-shadow: 0 2px 6px var(--item-sheet-shadow);
+}
+
+.myrpg.item-sheet .item-fields-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 }
 
 .myrpg.item-sheet .editor {
-  border: 1px solid #d4cbc0;
-  border-radius: 6px;
+  border: 1px solid var(--item-sheet-border);
+  border-radius: 10px;
   padding: 0.75rem;
   background-color: #ffffff;
   min-height: 120px;
@@ -208,12 +313,28 @@ textarea[disabled] {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  align-items: flex-start;
+  align-items: stretch;
+  width: 100%;
 }
 
 .myrpg.item-sheet .editor-content {
   min-height: 96px;
   width: 100%;
+}
+
+@media (max-width: 640px) {
+  .myrpg.item-sheet .sheet-header {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .myrpg.item-sheet .item-image {
+    margin: 0 auto;
+  }
+
+  .myrpg.item-sheet .item-details {
+    align-items: stretch;
+  }
 }
 
 .center-attributes {

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.307",
+  "version": "2.308",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/item/armor-sheet.hbs
+++ b/templates/item/armor-sheet.hbs
@@ -1,50 +1,62 @@
 <form class="{{cssClass}} myrpg item-sheet armor-sheet" autocomplete="off">
-  <header class="sheet-header">
-    <h1 class="sheet-title">
-      <input
-        name="name"
-        type="text"
-        value="{{item.name}}"
-        placeholder="{{localize 'MY_RPG.Inventory.Name'}}"
-        {{#unless editable}}disabled{{/unless}}
+  <header class="sheet-header item-header">
+    <div class="item-image">
+      <img
+        src="{{item.img}}"
+        data-edit="img"
+        alt="{{item.name}}"
+        title="{{item.name}}"
       />
-    </h1>
-    <div class="item-meta flexrow">
-      <div class="flexcol">
-        <label>{{localize 'MY_RPG.AbilityConfig.Rank'}}</label>
-        <select name="system.rank" {{#unless editable}}disabled{{/unless}}>
-          {{#each rankOptions}}
-            <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
-          {{/each}}
-        </select>
+    </div>
+    <div class="item-details">
+      <h1 class="sheet-title">
+        <input
+          name="name"
+          type="text"
+          value="{{item.name}}"
+          placeholder="{{localize 'MY_RPG.Inventory.Name'}}"
+          {{#unless editable}}disabled{{/unless}}
+        />
+      </h1>
+      <div class="item-meta-grid">
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.AbilityConfig.Rank'}}</label>
+          <select name="system.rank" {{#unless editable}}disabled{{/unless}}>
+            {{#each rankOptions}}
+              <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+            {{/each}}
+          </select>
+        </div>
       </div>
     </div>
   </header>
 
   <section class="sheet-body">
-    <div class="form-group grid grid-2col">
-      <div class="form-field">
-        <label>{{localize 'MY_RPG.ArmorItem.BonusPhysicalLabel'}}</label>
-        <input type="number" name="system.itemPhys" value="{{system.itemPhys}}" {{#unless editable}}disabled{{/unless}} />
-      </div>
-      <div class="form-field">
-        <label>{{localize 'MY_RPG.ArmorItem.BonusMagicalLabel'}}</label>
-        <input type="number" name="system.itemAzure" value="{{system.itemAzure}}" {{#unless editable}}disabled{{/unless}} />
-      </div>
-      <div class="form-field">
-        <label>{{localize 'MY_RPG.ArmorItem.BonusPsychicLabel'}}</label>
-        <input type="number" name="system.itemMental" value="{{system.itemMental}}" {{#unless editable}}disabled{{/unless}} />
-      </div>
-      <div class="form-field">
-        <label>{{localize 'MY_RPG.ArmorItem.ShieldLabel'}}</label>
-        <input type="number" name="system.itemShield" value="{{system.itemShield}}" {{#unless editable}}disabled{{/unless}} />
-      </div>
-      <div class="form-field">
-        <label>{{localize 'MY_RPG.ArmorItem.BonusSpeedLabel'}}</label>
-        <input type="number" name="system.itemSpeed" value="{{system.itemSpeed}}" {{#unless editable}}disabled{{/unless}} />
+    <div class="item-section">
+      <div class="item-fields-grid">
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.ArmorItem.BonusPhysicalLabel'}}</label>
+          <input type="number" name="system.itemPhys" value="{{system.itemPhys}}" {{#unless editable}}disabled{{/unless}} />
+        </div>
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.ArmorItem.BonusMagicalLabel'}}</label>
+          <input type="number" name="system.itemAzure" value="{{system.itemAzure}}" {{#unless editable}}disabled{{/unless}} />
+        </div>
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.ArmorItem.BonusPsychicLabel'}}</label>
+          <input type="number" name="system.itemMental" value="{{system.itemMental}}" {{#unless editable}}disabled{{/unless}} />
+        </div>
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.ArmorItem.ShieldLabel'}}</label>
+          <input type="number" name="system.itemShield" value="{{system.itemShield}}" {{#unless editable}}disabled{{/unless}} />
+        </div>
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.ArmorItem.BonusSpeedLabel'}}</label>
+          <input type="number" name="system.itemSpeed" value="{{system.itemSpeed}}" {{#unless editable}}disabled{{/unless}} />
+        </div>
       </div>
     </div>
-    <div class="form-group rich-text-field">
+    <div class="item-section rich-text-field">
       <label>{{localize 'MY_RPG.Inventory.Description'}}</label>
       <textarea
         name="system.description"

--- a/templates/item/cartridge-sheet.hbs
+++ b/templates/item/cartridge-sheet.hbs
@@ -1,60 +1,72 @@
 <form class="{{cssClass}} myrpg item-sheet cartridge-sheet" autocomplete="off">
-  <header class="sheet-header">
-    <h1 class="sheet-title">
-      <input
-        name="name"
-        type="text"
-        value="{{item.name}}"
-        placeholder="{{localize 'MY_RPG.Inventory.Name'}}"
-        {{#unless editable}}disabled{{/unless}}
+  <header class="sheet-header item-header">
+    <div class="item-image">
+      <img
+        src="{{item.img}}"
+        data-edit="img"
+        alt="{{item.name}}"
+        title="{{item.name}}"
       />
-    </h1>
-    <div class="item-meta flexrow">
-      <div class="flexcol">
-        <label>{{localize 'MY_RPG.AbilityConfig.Rank'}}</label>
-        <select name="system.rank" {{#unless editable}}disabled{{/unless}}>
-          {{#each rankOptions}}
-            <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
-          {{/each}}
-        </select>
-      </div>
-      {{#if showRuneType}}
-        <div class="flexcol">
-          <label>{{localize 'MY_RPG.AbilityConfig.RuneType'}}</label>
-          <select name="system.runeType" {{#unless editable}}disabled{{/unless}}>
-            {{#each runeTypeOptions}}
+    </div>
+    <div class="item-details">
+      <h1 class="sheet-title">
+        <input
+          name="name"
+          type="text"
+          value="{{item.name}}"
+          placeholder="{{localize 'MY_RPG.Inventory.Name'}}"
+          {{#unless editable}}disabled{{/unless}}
+        />
+      </h1>
+      <div class="item-meta-grid">
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.AbilityConfig.Rank'}}</label>
+          <select name="system.rank" {{#unless editable}}disabled{{/unless}}>
+            {{#each rankOptions}}
               <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
             {{/each}}
           </select>
         </div>
-      {{/if}}
+        {{#if showRuneType}}
+          <div class="item-field">
+            <label>{{localize 'MY_RPG.AbilityConfig.RuneType'}}</label>
+            <select name="system.runeType" {{#unless editable}}disabled{{/unless}}>
+              {{#each runeTypeOptions}}
+                <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+              {{/each}}
+            </select>
+          </div>
+        {{/if}}
+      </div>
     </div>
   </header>
 
   <section class="sheet-body">
-    <div class="form-group rich-text-field">
+    <div class="item-section rich-text-field">
       <label>{{localize 'MY_RPG.AbilityConfig.Effect'}}</label>
       {{editor system.effect target="system.effect" button=false owner=owner editable=editable}}
     </div>
-    <div class="form-group flexrow">
-      <div class="flexcol">
-        <label>{{localize 'MY_RPG.AbilityConfig.Upgrade1'}}</label>
-        <select name="system.upgrade1" {{#unless editable}}disabled{{/unless}}>
-          {{#each upgradeOptions}}
-            <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
-          {{/each}}
-        </select>
-      </div>
-      <div class="flexcol">
-        <label>{{localize 'MY_RPG.AbilityConfig.Upgrade2'}}</label>
-        <select name="system.upgrade2" {{#unless editable}}disabled{{/unless}}>
-          {{#each upgradeOptionsSecondary}}
-            <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
-          {{/each}}
-        </select>
+    <div class="item-section">
+      <div class="item-fields-grid">
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.AbilityConfig.Upgrade1'}}</label>
+          <select name="system.upgrade1" {{#unless editable}}disabled{{/unless}}>
+            {{#each upgradeOptions}}
+              <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+            {{/each}}
+          </select>
+        </div>
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.AbilityConfig.Upgrade2'}}</label>
+          <select name="system.upgrade2" {{#unless editable}}disabled{{/unless}}>
+            {{#each upgradeOptionsSecondary}}
+              <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+            {{/each}}
+          </select>
+        </div>
       </div>
     </div>
-    <div class="form-group rich-text-field">
+    <div class="item-section rich-text-field">
       <label>{{localize 'MY_RPG.Inventory.Description'}}</label>
       <textarea
         name="system.description"

--- a/templates/item/gear-sheet.hbs
+++ b/templates/item/gear-sheet.hbs
@@ -1,38 +1,48 @@
 <form class="{{cssClass}} myrpg item-sheet gear-sheet" autocomplete="off">
-  <header class="sheet-header">
-    <h1 class="sheet-title">
-      <input
-        name="name"
-        type="text"
-        value="{{item.name}}"
-        placeholder="{{localize 'MY_RPG.Inventory.Name'}}"
-        {{#unless editable}}disabled{{/unless}}
+  <header class="sheet-header item-header">
+    <div class="item-image">
+      <img
+        src="{{item.img}}"
+        data-edit="img"
+        alt="{{item.name}}"
+        title="{{item.name}}"
       />
-    </h1>
-    <div class="item-meta flexrow">
-      <div class="flexcol">
-        <label>{{localize 'MY_RPG.Inventory.Quantity'}}</label>
+    </div>
+    <div class="item-details">
+      <h1 class="sheet-title">
         <input
-          type="number"
-          name="system.quantity"
-          value="{{system.quantity}}"
-          min="0"
+          name="name"
+          type="text"
+          value="{{item.name}}"
+          placeholder="{{localize 'MY_RPG.Inventory.Name'}}"
           {{#unless editable}}disabled{{/unless}}
         />
-      </div>
-      <div class="flexcol">
-        <label>{{localize 'MY_RPG.AbilityConfig.Rank'}}</label>
-        <select name="system.rank" {{#unless editable}}disabled{{/unless}}>
-          {{#each rankOptions}}
-            <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
-          {{/each}}
-        </select>
+      </h1>
+      <div class="item-meta-grid">
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.Inventory.Quantity'}}</label>
+          <input
+            type="number"
+            name="system.quantity"
+            value="{{system.quantity}}"
+            min="0"
+            {{#unless editable}}disabled{{/unless}}
+          />
+        </div>
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.AbilityConfig.Rank'}}</label>
+          <select name="system.rank" {{#unless editable}}disabled{{/unless}}>
+            {{#each rankOptions}}
+              <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+            {{/each}}
+          </select>
+        </div>
       </div>
     </div>
   </header>
 
   <section class="sheet-body">
-    <div class="form-group rich-text-field">
+    <div class="item-section rich-text-field">
       <label>{{localize 'MY_RPG.Inventory.Description'}}</label>
       <textarea
         name="system.description"

--- a/templates/item/implant-sheet.hbs
+++ b/templates/item/implant-sheet.hbs
@@ -1,50 +1,62 @@
 <form class="{{cssClass}} myrpg item-sheet implant-sheet" autocomplete="off">
-  <header class="sheet-header">
-    <h1 class="sheet-title">
-      <input
-        name="name"
-        type="text"
-        value="{{item.name}}"
-        placeholder="{{localize 'MY_RPG.Inventory.Name'}}"
-        {{#unless editable}}disabled{{/unless}}
+  <header class="sheet-header item-header">
+    <div class="item-image">
+      <img
+        src="{{item.img}}"
+        data-edit="img"
+        alt="{{item.name}}"
+        title="{{item.name}}"
       />
-    </h1>
-    <div class="item-meta flexrow">
-      <div class="flexcol">
-        <label>{{localize 'MY_RPG.ModsTable.Rank'}}</label>
-        <select name="system.rank" {{#unless editable}}disabled{{/unless}}>
-          {{#each rankOptions}}
-            <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
-          {{/each}}
-        </select>
+    </div>
+    <div class="item-details">
+      <h1 class="sheet-title">
+        <input
+          name="name"
+          type="text"
+          value="{{item.name}}"
+          placeholder="{{localize 'MY_RPG.Inventory.Name'}}"
+          {{#unless editable}}disabled{{/unless}}
+        />
+      </h1>
+      <div class="item-meta-grid">
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.ModsTable.Rank'}}</label>
+          <select name="system.rank" {{#unless editable}}disabled{{/unless}}>
+            {{#each rankOptions}}
+              <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+            {{/each}}
+          </select>
+        </div>
       </div>
     </div>
   </header>
 
   <section class="sheet-body">
-    <div class="form-group rich-text-field">
+    <div class="item-section rich-text-field">
       <label>{{localize 'MY_RPG.ModsTable.Effect'}}</label>
       {{editor system.effect target="system.effect" button=false owner=owner editable=editable}}
     </div>
-    <div class="form-group flexrow">
-      <div class="flexcol">
-        <label>{{localize 'MY_RPG.AbilityConfig.Upgrade1'}}</label>
-        <select name="system.upgrade1" {{#unless editable}}disabled{{/unless}}>
-          {{#each upgradeOptions}}
-            <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
-          {{/each}}
-        </select>
-      </div>
-      <div class="flexcol">
-        <label>{{localize 'MY_RPG.AbilityConfig.Upgrade2'}}</label>
-        <select name="system.upgrade2" {{#unless editable}}disabled{{/unless}}>
-          {{#each upgradeOptionsSecondary}}
-            <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
-          {{/each}}
-        </select>
+    <div class="item-section">
+      <div class="item-fields-grid">
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.AbilityConfig.Upgrade1'}}</label>
+          <select name="system.upgrade1" {{#unless editable}}disabled{{/unless}}>
+            {{#each upgradeOptions}}
+              <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+            {{/each}}
+          </select>
+        </div>
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.AbilityConfig.Upgrade2'}}</label>
+          <select name="system.upgrade2" {{#unless editable}}disabled{{/unless}}>
+            {{#each upgradeOptionsSecondary}}
+              <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+            {{/each}}
+          </select>
+        </div>
       </div>
     </div>
-    <div class="form-group rich-text-field">
+    <div class="item-section rich-text-field">
       <label>{{localize 'MY_RPG.Inventory.Description'}}</label>
       <textarea
         name="system.description"

--- a/templates/item/weapon-sheet.hbs
+++ b/templates/item/weapon-sheet.hbs
@@ -1,47 +1,59 @@
 <form class="{{cssClass}} myrpg item-sheet weapon-sheet" autocomplete="off">
-  <header class="sheet-header">
-    <h1 class="sheet-title">
-      <input
-        name="name"
-        type="text"
-        value="{{item.name}}"
-        placeholder="{{localize 'MY_RPG.Inventory.Name'}}"
-        {{#unless editable}}disabled{{/unless}}
+  <header class="sheet-header item-header">
+    <div class="item-image">
+      <img
+        src="{{item.img}}"
+        data-edit="img"
+        alt="{{item.name}}"
+        title="{{item.name}}"
       />
-    </h1>
-    <div class="item-meta flexrow">
-      <div class="flexcol">
-        <label>{{localize 'MY_RPG.AbilityConfig.Rank'}}</label>
-        <select name="system.rank" {{#unless editable}}disabled{{/unless}}>
-          {{#each rankOptions}}
-            <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
-          {{/each}}
-        </select>
+    </div>
+    <div class="item-details">
+      <h1 class="sheet-title">
+        <input
+          name="name"
+          type="text"
+          value="{{item.name}}"
+          placeholder="{{localize 'MY_RPG.Inventory.Name'}}"
+          {{#unless editable}}disabled{{/unless}}
+        />
+      </h1>
+      <div class="item-meta-grid">
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.AbilityConfig.Rank'}}</label>
+          <select name="system.rank" {{#unless editable}}disabled{{/unless}}>
+            {{#each rankOptions}}
+              <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+            {{/each}}
+          </select>
+        </div>
       </div>
     </div>
   </header>
 
   <section class="sheet-body">
-    <div class="form-group flexrow">
-      <div class="flexcol">
-        <label>{{localize 'MY_RPG.WeaponsTable.SkillLabel'}}</label>
-        <select name="system.skill" {{#unless editable}}disabled{{/unless}}>
-          {{#each skillOptions}}
-            <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
-          {{/each}}
-        </select>
-      </div>
-      <div class="flexcol">
-        <label>{{localize 'MY_RPG.WeaponsTable.BonusLabel'}}</label>
-        <input
-          type="number"
-          name="system.skillBonus"
-          value="{{system.skillBonus}}"
-          {{#unless editable}}disabled{{/unless}}
-        />
+    <div class="item-section">
+      <div class="item-fields-grid">
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.WeaponsTable.SkillLabel'}}</label>
+          <select name="system.skill" {{#unless editable}}disabled{{/unless}}>
+            {{#each skillOptions}}
+              <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
+            {{/each}}
+          </select>
+        </div>
+        <div class="item-field">
+          <label>{{localize 'MY_RPG.WeaponsTable.BonusLabel'}}</label>
+          <input
+            type="number"
+            name="system.skillBonus"
+            value="{{system.skillBonus}}"
+            {{#unless editable}}disabled{{/unless}}
+          />
+        </div>
       </div>
     </div>
-    <div class="form-group rich-text-field">
+    <div class="item-section rich-text-field">
       <label>{{localize 'MY_RPG.Inventory.Description'}}</label>
       <textarea
         name="system.description"


### PR DESCRIPTION
## Summary
- restyle item sheet headers with a prominent image preview and responsive metadata layout
- reorganize item form sections for weapons, armor, gear, cartridges, and implants to improve readability
- bump the system version to 2.308

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_69061158e40c832eb071eace75492002