### PR TITLE
Add cartridge and implant roll button

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -304,12 +304,16 @@
       "Edit": "Edit",
       "Delete": "Delete",
       "Chat": "Send to chat",
+      "Roll": "Roll",
       "Equip": "Equipped",
       "EquipAria": "Toggle equipped state",
       "Quantity": "Quantity",
       "QuantityIncrease": "Increase quantity",
       "QuantityDecrease": "Decrease quantity",
       "NewItemFallback": "New {type}"
+    },
+    "ItemRoll": {
+      "Flavor": "Rolling {item} ({skill})"
     },
     "ItemDialogs": {
       "DeleteTitle": "Delete {type}",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -311,12 +311,16 @@
       "Edit": "Изменить",
       "Delete": "Удалить",
       "Chat": "Отправить в чат",
+      "Roll": "Бросок",
       "Equip": "Снаряжено",
       "EquipAria": "Переключить статус экипировки",
       "Quantity": "Количество",
       "QuantityIncrease": "Увеличить количество",
       "QuantityDecrease": "Уменьшить количество",
       "NewItemFallback": "Новый {type}"
+    },
+    "ItemRoll": {
+      "Flavor": "Бросок {item} ({skill})"
     },
     "ItemDialogs": {
       "DeleteTitle": "Удалить {type}",

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/myrpg/assets/anvil-impact.png"
     }
   ],
-  "version": "2.310",
+  "version": "2.311",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -474,6 +474,18 @@
                               />
                             </label>
                           {{/if}}
+                          {{#if item.canRoll}}
+                            <button
+                              type='button'
+                              class='item-roll item-control'
+                              data-item-id='{{item.id}}'
+                              data-group-key='{{item.groupKey}}'
+                              title='{{../../itemControls.roll}}'
+                            >
+                              <i class='fa-solid fa-dice-d10'></i>
+                              <span class='sr-only'>{{../../itemControls.roll}}</span>
+                            </button>
+                          {{/if}}
                           <button
                             type='button'
                             class='item-chat item-control'


### PR DESCRIPTION
## Summary
- add a dedicated dice roll control for cartridge and implant entries on the actor sheet
- calculate the roll as 1d10 plus the actor skill value and the item's bonus with localized chat output
- add localisation strings for the new control and bump the system version

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_69064b5fb250832eb17fa7b460fab8a1