### PR TITLE
fix: remove redundant actor sheet close override

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -94,11 +94,6 @@ export class myrpgActorSheet extends ActorSheet {
 
     this.element.find('.sheet-scrollable').scrollTop(scrollPos);
   }
-
-  async close(options = {}) {
-    return super.close(options);
-  }
-
   validateNumericInput(input) {
     let val = parseInt(input.value, 10);
     const isAbility = input.name.includes('system.abilities.');


### PR DESCRIPTION
## Summary
- remove the myrpg actor sheet close override so the base ActorSheet implementation is used

## Testing
- `npx --yes eslint@9.28.0 .` *(fails: existing lint errors about undefined globals such as Item, Items, console, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_690687d03ae0832ea3e420c8a3a087e2