### PR TITLE
Switch abilities to dice-based checks

### DIFF
--- a/css/project-andromeda.css
+++ b/css/project-andromeda.css
@@ -149,6 +149,41 @@ textarea[disabled] {
   text-align: center;
   padding: 5px !important;
 }
+
+.ability-die-control {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.ability-die-value {
+  min-width: 52px;
+  padding: 6px 10px;
+  border: 2px solid #1b1210;
+  border-radius: 8px;
+  font-weight: 700;
+  background: #f5f0e8;
+  text-transform: uppercase;
+}
+
+.ability-step {
+  width: 26px;
+  height: 26px;
+  border: 1px solid #1b1210;
+  background: #ffffff;
+  border-radius: 6px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.ability-step:hover,
+.ability-step:focus {
+  background-color: #d2d2c9;
+}
 .attributes-table thead th {
   background-color: #673e37;
   color: #d2d2c9;

--- a/lang/en.json
+++ b/lang/en.json
@@ -189,6 +189,10 @@
     },
     "SendToChat": "Send to Chat",
     "MinimalBonus": "minimal bonus",
+    "AbilityDice": {
+      "Increase": "Increase characteristic die",
+      "Decrease": "Decrease characteristic die"
+    },
     "abilityAbbreviations": {
       "spi": "Spi",
       "con": "Body",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -196,6 +196,10 @@
     },
     "SendToChat": "Отправить в чат",
     "MinimalBonus": "минимальный бонус",
+    "AbilityDice": {
+      "Increase": "Увеличить куб характеристики",
+      "Decrease": "Уменьшить куб характеристики"
+    },
     "abilityAbbreviations": {
       "spi": "Дух",
       "con": "Тело",

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1,4 +1,5 @@
 import { debugLog } from '../config.mjs';
+import { normalizeAbilityDie } from '../helpers/utils.mjs';
 
 /**
  * Extend the base Actor document by defining a custom roll data structure which is ideal for the Simple system.
@@ -20,6 +21,7 @@ export class ProjectAndromedaActor extends Actor {
 
     /* 1. Способности ---------------------------------------------- */
     for (const a of Object.values(s.abilities ?? {})) {
+      a.value = normalizeAbilityDie(a.value);
       a.mod = a.value; // «бонус» = само значение
     }
 

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -13,3 +13,18 @@ export function getColorRank(val = 0) {
   if (val <= 8) return 4;
   return 5;
 }
+
+export const ABILITY_DIE_STEPS = [4, 6, 8, 10, 12];
+
+export function normalizeAbilityDie(value) {
+  const numeric = Number(value);
+  if (ABILITY_DIE_STEPS.includes(numeric)) return numeric;
+  const clamped = Math.max(Math.min(numeric || 0, Math.max(...ABILITY_DIE_STEPS)), Math.min(...ABILITY_DIE_STEPS));
+  let closest = ABILITY_DIE_STEPS[0];
+  for (const die of ABILITY_DIE_STEPS) {
+    if (Math.abs(die - clamped) < Math.abs(closest - clamped)) {
+      closest = die;
+    }
+  }
+  return closest;
+}

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/Project_Andromeda/assets/Art_core_1.jpg"
     }
   ],
-  "version": "2.320",
+  "version": "2.321",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/template.json
+++ b/template.json
@@ -10,13 +10,13 @@
         "momentOfGlory": 0,
         "abilities": {
           "spi": {
-            "value": 0
+            "value": 4
           },
           "con": {
-            "value": 0
+            "value": 4
           },
           "int": {
-            "value": 0
+            "value": 4
           }
         },
         "cartridgesList": [],

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -114,15 +114,28 @@
                   <tr>
                     {{#each system.abilities as |ability key|}}
                       <td>
-                        <input
-                          class='{{ability.rankClass}}'
-                          type='number'
-                          name='system.abilities.{{key}}.value'
-                          value='{{ability.value}}'
-                          step='1'
-                          inputmode='numeric'
-                          pattern='\d+'
-                        />
+                        <div class='ability-die-control' data-ability-key='{{key}}'>
+                          <button
+                            type='button'
+                            class='ability-step'
+                            data-step='-1'
+                            aria-label='{{localize "MY_RPG.AbilityDice.Decrease"}}'
+                          >
+                            <span aria-hidden='true'>-</span>
+                          </button>
+                          <div class='ability-die-value {{ability.rankClass}}'>
+                            {{ability.dieLabel}}
+                          </div>
+                          <button
+                            type='button'
+                            class='ability-step'
+                            data-step='1'
+                            aria-label='{{localize "MY_RPG.AbilityDice.Increase"}}'
+                          >
+                            <span aria-hidden='true'>+</span>
+                          </button>
+                          <input type='hidden' name='system.abilities.{{key}}.value' value='{{ability.value}}' />
+                        </div>
                       </td>
                     {{/each}}
                   </tr>


### PR DESCRIPTION
## Summary
- display abilities as adjustable dice steps from d4 to d12 and normalize stored values
- update skill and ability rolls to use the associated ability die plus skill modifiers
- refresh localization, styling, defaults, and system version for the new dice mechanic

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947277dedb8832e9e1db94e167aefb7)