### PR TITLE
Adjust rank count and color mapping

### DIFF
--- a/css/project-andromeda.css
+++ b/css/project-andromeda.css
@@ -6,19 +6,15 @@
 
 /* Rank colors -------------------------------------------------- */
 :root {
-  /* фоны не меняем */
   --rank1-bg: #c7e6b3;
-  --rank2-bg: #f5a75a;
-  --rank3-bg: #a5a9b4;
-  --rank4-bg: #fcd75f;
-  --rank5-bg: #87d0fb;
+  --rank2-bg: #a5a9b4;
+  --rank3-bg: #fcd75f;
+  --rank4-bg: #87d0fb;
 
-  /* новые рамки с контрастом ≈ 1.9 : 1 */
   --rank1-border: #6ab23b; /* контраст 1.91 */
-  --rank2-border: #c96a0c; /* 1.90 */
-  --rank3-border: #717788; /* 1.90 */
-  --rank4-border: #c69804; /* 1.90 */
-  --rank5-border: #0896e9; /* 1.90 */
+  --rank2-border: #717788; /* 1.90 */
+  --rank3-border: #c69804; /* 1.90 */
+  --rank4-border: #0896e9; /* 1.90 */
 }
 
 .small-input {
@@ -1050,17 +1046,11 @@ section.abilities-section {
   --rank-border: var(--rank4-border);
   color: var(--rank4-border);
 }
-.rank5 {
-  --rank-bg: var(--rank5-bg);
-  --rank-border: var(--rank5-border);
-  color: var(--rank5-border);
-}
 
 input.rank1,
 input.rank2,
 input.rank3,
-input.rank4,
-input.rank5 {
+input.rank4 {
   background-color: var(--rank-bg) !important;
   border-color: var(--rank-border) !important;
   color: #000;
@@ -1069,8 +1059,7 @@ input.rank5 {
 .skill-name.rank1,
 .skill-name.rank2,
 .skill-name.rank3,
-.skill-name.rank4,
-.skill-name.rank5 {
+.skill-name.rank4 {
   background-color: var(--rank-bg);
   border-color: var(--rank-border);
   color: #000;
@@ -1079,8 +1068,7 @@ input.rank5 {
 .rank-hint-table td.rank1,
 .rank-hint-table td.rank2,
 .rank-hint-table td.rank3,
-.rank-hint-table td.rank4,
-.rank-hint-table td.rank5 {
+.rank-hint-table td.rank4 {
   background-color: var(--rank-bg);
   color: #1b1210;
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -32,17 +32,15 @@
     "RankGradient": {
       "Title": "Rank Gradient",
       "Rank1": "Wood",
-      "Rank2": "Bronze",
-      "Rank3": "Silver",
-      "Rank4": "Gold",
-      "Rank5": "Sky"
+      "Rank2": "Silver",
+      "Rank3": "Gold",
+      "Rank4": "Sky"
     },
     "RankNumeric": {
       "Rank1": "Rank 1",
       "Rank2": "Rank 2",
       "Rank3": "Rank 3",
-      "Rank4": "Rank 4",
-      "Rank5": "Rank 5"
+      "Rank4": "Rank 4"
     },
     "KeyInfo": {
       "Calling": "Calling",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -37,17 +37,15 @@
     "RankGradient": {
       "Title": "Градация рангов",
       "Rank1": "Дерево",
-      "Rank2": "Бронза",
-      "Rank3": "Серебро",
-      "Rank4": "Золото",
-      "Rank5": "Небо"
+      "Rank2": "Серебро",
+      "Rank3": "Золото",
+      "Rank4": "Небо"
     },
     "RankNumeric": {
       "Rank1": "Ранг 1",
       "Rank2": "Ранг 2",
       "Rank3": "Ранг 3",
-      "Rank4": "Ранг 4",
-      "Rank5": "Ранг 5"
+      "Rank4": "Ранг 4"
     },
     "ArmorItem": {
       "ArmorSectionTitle": "Доспех",

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -1,17 +1,25 @@
 // Utility functions for the Project Andromeda system
 
 /**
- * Determine a simplified rank (1-5) based on a value in steps of two.
- * Used purely for coloring cells in the UI.
+ * Determine a simplified rank (1-4) used purely for coloring cells in the UI.
  * @param {number} [val=0] The value to rank.
- * @returns {number} Rank between 1 and 5
+ * @param {'ability' | 'skill'} [type='skill'] Determines which thresholds to use.
+ * @returns {number} Rank between 1 and 4
  */
-export function getColorRank(val = 0) {
-  if (val <= 2) return 1;
-  if (val <= 4) return 2;
-  if (val <= 6) return 3;
-  if (val <= 8) return 4;
-  return 5;
+export function getColorRank(val = 0, type = 'skill') {
+  const numeric = Number(val) || 0;
+
+  if (type === 'ability') {
+    if (numeric <= 6) return 1;
+    if (numeric <= 8) return 2;
+    if (numeric <= 10) return 3;
+    return 4;
+  }
+
+  if (numeric <= 1) return 1;
+  if (numeric <= 3) return 2;
+  if (numeric <= 6) return 3;
+  return 4;
 }
 
 export const ABILITY_DIE_STEPS = [4, 6, 8, 10, 12];

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -267,7 +267,7 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
     for (let [k, v] of Object.entries(context.system.abilities)) {
       v.value = normalizeAbilityDie(v.value);
       v.label = game.i18n.localize(CONFIG.ProjectAndromeda.abilities[k]) ?? k;
-      v.rankClass = 'rank' + getColorRank(v.value);
+      v.rankClass = 'rank' + getColorRank(v.value, 'ability');
       v.dieLabel = `d${v.value}`;
     }
     const order = [
@@ -290,7 +290,7 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
       if (context.system.skills[key]) {
         const c = context.system.skills[key];
         c.label = game.i18n.localize(CONFIG.ProjectAndromeda.skills[key]) ?? key;
-        c.rankClass = 'rank' + getColorRank(c.value);
+        c.rankClass = 'rank' + getColorRank(c.value, 'skill');
         sorted[key] = c;
       }
     }
@@ -410,11 +410,11 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
   _updateAbilityDisplays(root, abilityKey) {
     const $root = root instanceof jQuery ? root : $(root ?? this.element);
     const abilityKeys = abilityKey ? [abilityKey] : Object.keys(this.actor.system?.abilities ?? {});
-    const rankClasses = ['rank1', 'rank2', 'rank3', 'rank4', 'rank5'];
+    const rankClasses = ['rank1', 'rank2', 'rank3', 'rank4'];
 
     for (const key of abilityKeys) {
       const dieValue = this._getAbilityDieValue(key);
-      const rankClass = 'rank' + getColorRank(dieValue);
+      const rankClass = 'rank' + getColorRank(dieValue, 'ability');
       const $container = $root.find(`[data-ability-key="${key}"]`);
 
       $container.find('.ability-die-value')

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -12,7 +12,7 @@ function buildRankOptions(selected) {
     }
   ];
 
-  for (let rank = 1; rank <= 5; rank += 1) {
+  for (let rank = 1; rank <= 4; rank += 1) {
     options.push({
       value: String(rank),
       label: game.i18n.localize(`${baseKey}.Rank${rank}`),

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/Project_Andromeda/assets/Art_core_1.jpg"
     }
   ],
-  "version": "2.322",
+  "version": "2.323",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -143,14 +143,13 @@
               </table>
 <table class="rank-hint-table attributes-table">
   <tr>
-    <th colspan='5'>{{localize 'MY_RPG.RankGradient.Title'}}</th>
+    <th colspan='4'>{{localize 'MY_RPG.RankGradient.Title'}}</th>
   </tr>
   <tr>
     <td class='rank1'>{{rankLabel 1}}</td>
     <td class='rank2'>{{rankLabel 2}}</td>
     <td class='rank3'>{{rankLabel 3}}</td>
     <td class='rank4'>{{rankLabel 4}}</td>
-    <td class='rank5'>{{rankLabel 5}}</td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Summary
- reduce rank options to four and remap colors using the prior palette
- update ability and skill rank thresholds and sheet hints to the four-rank scheme
- align localization strings and version for the new rank structure

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947c5e6c6c4832eb85d11a3e037ac41)