### PR TITLE
feat: reorder abilities and reorganize skills

### DIFF
--- a/css/project-andromeda.css
+++ b/css/project-andromeda.css
@@ -460,14 +460,29 @@ form input[type='number'] {
   margin-bottom: 5px;
 }
 
-/* layout skills into two columns */
+/* layout skills into three characteristic columns */
 .skills-grid {
-  column-count: 2;
-  column-gap: 10px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
 }
 
-.skills-grid .skill-row {
-  break-inside: avoid;
+.skills-column {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.skills-column-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  padding: 0 4px;
+}
+
+.skills-column-title {
+  font-size: 1rem;
 }
 
 /*         resizable   textarea */

--- a/lang/en.json
+++ b/lang/en.json
@@ -218,7 +218,7 @@
       "Blizhniy_boy": "Melee",
       "Nablyudatelnost": "Observation",
       "Analiz": "Analysis",
-      "Programmirovanie": "Programming",
+      "Programmirovanie": "Hacking",
       "Inzheneriya": "Engineering",
       "Dominirovanie": "Dominance",
       "Rezonans": "Resonance",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -225,7 +225,7 @@
       "Blizhniy_boy": "Ближний бой",
       "Nablyudatelnost": "Наблюдательность",
       "Analiz": "Анализ",
-      "Programmirovanie": "Взлом",
+      "Programmirovanie": "Хакерство",
       "Inzheneriya": "Инженерия",
       "Dominirovanie": "Доминирование",
       "Rezonans": "Резонанс",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -225,7 +225,7 @@
       "Blizhniy_boy": "Ближний бой",
       "Nablyudatelnost": "Наблюдательность",
       "Analiz": "Анализ",
-      "Programmirovanie": "Программирование",
+      "Programmirovanie": "Взлом",
       "Inzheneriya": "Инженерия",
       "Dominirovanie": "Доминирование",
       "Rezonans": "Резонанс",

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -5,15 +5,15 @@ export const PROJECT_ANDROMEDA = {};
  * @type {Object}
  */
 PROJECT_ANDROMEDA.abilities = {
-  spi: 'MY_RPG.Ability.Spi.long', // �����/ Spirit�
   con: 'MY_RPG.Ability.Con.long',
-  int: 'MY_RPG.Ability.Int.long'
+  int: 'MY_RPG.Ability.Int.long',
+  spi: 'MY_RPG.Ability.Spi.long' // �����/ Spirit�
 };
 
 PROJECT_ANDROMEDA.abilityAbbreviations = {
-  spi: 'MY_RPG.Ability.Spi.abbr', // �����/ Spi�
   con: 'MY_RPG.Ability.Con.abbr',
-  int: 'MY_RPG.Ability.Int.abbr'
+  int: 'MY_RPG.Ability.Int.abbr',
+  spi: 'MY_RPG.Ability.Spi.abbr' // �����/ Spi�
 };
 
 PROJECT_ANDROMEDA.skills = {

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/Project_Andromeda/assets/Art_core_1.jpg"
     }
   ],
-  "version": "2.324",
+  "version": "2.325",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/template.json
+++ b/template.json
@@ -9,13 +9,13 @@
         "currentRank": "",
         "momentOfGlory": 0,
         "abilities": {
-          "spi": {
-            "value": 4
-          },
           "con": {
             "value": 4
           },
           "int": {
+            "value": 4
+          },
+          "spi": {
             "value": 4
           }
         },

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -318,33 +318,36 @@
           <div class='sheet-box'>
             <h2>{{localize 'MY_RPG.SheetLabels.Skills'}}</h2>
             <div class='skills-grid'>
-              {{#each system.skills as |skill key|}}
-                <div class='skill skill-row'>
-                  <!--                                 -->
-                  <div class='skill-col skill-ability-abbr'>
-                    {{localize (concat 'MY_RPG.abilityAbbreviations.' skill.ability)}}
+              {{#each skillColumns as |column|}}
+                <div class='skills-column'>
+                  <div class='skills-column-header'>
+                    <span class='skill-col skill-ability-abbr'>{{column.abbreviation}}</span>
+                    <span class='skills-column-title'>{{column.label}}</span>
                   </div>
+                  {{#each column.skills as |skill|}}
+                    <div class='skill skill-row'>
+                      <div
+                        class='skill-col skill-name rollable'
+                        data-skill='{{skill.key}}'
+                        data-label='{{skill.label}}'
+                      >
+                        {{skill.label}}
+                      </div>
 
-                  <div
-                    class='skill-col skill-name rollable'
-                    data-skill='{{key}}'
-                    data-label='{{localize (concat "MY_RPG.Skill." (toPascalCase key))}}'
-                  >
-                    {{localize (concat 'MY_RPG.Skill.' (toPascalCase key))}}
-                  </div>
-
-                  <div class='skill-col skill-value'>
-                    <input
-                      class='{{skill.rankClass}}'
-                      type='number'
-                      name='system.skills.{{key}}.value'
-                      value='{{skill.value}}'
-                      step='1'
-                      inputmode='numeric'
-                      pattern='\d+'
-                      min='0'
-                    />
-                  </div>
+                      <div class='skill-col skill-value'>
+                        <input
+                          class='{{skill.rankClass}}'
+                          type='number'
+                          name='system.skills.{{skill.key}}.value'
+                          value='{{skill.value}}'
+                          step='1'
+                          inputmode='numeric'
+                          pattern='\d+'
+                          min='0'
+                        />
+                      </div>
+                    </div>
+                  {{/each}}
                 </div>
               {{/each}}
             </div>


### PR DESCRIPTION
## Summary
- reorder displayed characteristics to Body, Mind, and Spirit
- rename the Programming skill to Hacking with updated localisation
- organize the skills grid into three characteristic-based columns and adjust styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947d0b6e1d0832ea0c7575f888b5bf5)