### PR TITLE
Add weapon damage roll note and chat button

### DIFF
--- a/css/project-andromeda.css
+++ b/css/project-andromeda.css
@@ -1332,3 +1332,8 @@ input.rank4 {
 .myrpg-roll-part__value {
   font-weight: 600;
 }
+
+.myrpg-roll-note {
+  font-size: 0.95em;
+  font-weight: 600;
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -158,7 +158,7 @@
       "SkillLabel": "Skill",
       "SkillNone": "No skill selected",
       "SkillNoneOption": "No skill selected",
-      "BonusLabel": "Skill Bonus",
+      "DamageLabel": "Damage",
       "DescriptionLabel": "Description",
       "EquippedLabel": "Equipped"
     },
@@ -306,6 +306,7 @@
       "SkillValue": "Skill ({skill})",
       "WoundPenalty": "Wound penalty",
       "EquipmentBonus": "Equipment bonus",
+      "Damage": "Damage {value}",
       "SourceWeapon": "Weapon: {name}",
       "SourceCartridge": "Cartridge: {name}",
       "SourceImplant": "Implant: {name}",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -74,7 +74,7 @@
       "SkillLabel": "Навык",
       "SkillNone": "Навык не выбран",
       "SkillNoneOption": "Навык не выбран",
-      "BonusLabel": "Бонус к навыку",
+      "DamageLabel": "Урон",
       "DescriptionLabel": "Описание",
       "EquippedLabel": "Экипировано"
     },
@@ -313,6 +313,7 @@
       "SkillValue": "Навык ({skill})",
       "WoundPenalty": "Штраф за ранения",
       "EquipmentBonus": "Бонус экипировки",
+      "Damage": "Урон {value}",
       "SourceWeapon": "Оружие: {name}",
       "SourceCartridge": "Картридж: {name}",
       "SourceImplant": "Имплант: {name}",

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -188,22 +188,6 @@ export class ProjectAndromedaActor extends Actor {
       totals.armor.speed += (Number(system.itemSpeed) || 0) * quantity;
     }
 
-    const weaponItems = this.itemTypes?.weapon ?? [];
-    for (const weapon of weaponItems) {
-      const system = weapon.system ?? {};
-      if (!system.equipped) continue;
-      const skill = String(system.skill || '');
-      if (!skill) continue;
-      const quantity = Math.max(Number(system.quantity) || 1, 0);
-      const bonus = (Number(system.skillBonus) || 0) * quantity;
-      if (!bonus) continue;
-      addSkillBonus(skill, bonus, {
-        type: 'weapon',
-        name: itemName(weapon, 'weapon'),
-        quantity
-      });
-    }
-
     const cartridgeItems = this.itemTypes?.cartridge ?? [];
     for (const cartridge of cartridgeItems) {
       const system = cartridge.system ?? {};

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/Project_Andromeda/assets/Art_core_1.jpg"
     }
   ],
-  "version": "2.327",
+  "version": "2.328",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/item/weapon-sheet.hbs
+++ b/templates/item/weapon-sheet.hbs
@@ -43,7 +43,7 @@
           </select>
         </div>
         <div class="item-field">
-          <label>{{localize 'MY_RPG.WeaponsTable.BonusLabel'}}</label>
+          <label>{{localize 'MY_RPG.WeaponsTable.DamageLabel'}}</label>
           <input
             type="number"
             name="system.skillBonus"


### PR DESCRIPTION
## Summary
- allow weapons to be rolled from the inventory similar to cartridges and implants
- rename the weapon bonus to damage and surface it as a separate note in chat
- remove weapon bonuses from passive skill totals and bump the system version

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947f20413c4832eb08f987fca4512e7)