### PR TITLE
Add weapon roll button and remove weapon equip handling

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -75,6 +75,10 @@ export class ProjectAndromedaItem extends Item {
       overwrite: false,
       inplace: true
     });
+
+    if (this.type === 'weapon') {
+      delete systemData.equipped;
+    }
   }
 
   get isCartridge() {

--- a/module/helpers/migrations.mjs
+++ b/module/helpers/migrations.mjs
@@ -222,15 +222,18 @@ function buildSystemData(normalizedEntry, config) {
         ['rank', 'rankValue', 'rankLabel', 'currentRank', 'level', 'tier', 'rarity', 'quality'],
         ''
       )
-    ),
-    equipped: normalizeBoolean(
+    )
+  };
+
+  if (config?.itemType !== 'weapon') {
+    baseSystem.equipped = normalizeBoolean(
       getLegacyField(
         normalizedEntry,
         ['equipped', 'isEquipped', 'active', 'isActive', 'enabled', 'isEnabled', 'worn', 'wielded'],
         false
       )
-    )
-  };
+    );
+  }
 
   const extraSystem = config?.buildSystem?.(normalizedEntry) ?? {};
   return cleanObject({

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -44,7 +44,7 @@ const ITEM_GROUP_CONFIG = [
     createKey: 'MY_RPG.ItemGroups.CreateWeapon',
     newNameKey: 'MY_RPG.ItemGroups.NewWeapon',
     showQuantity: false,
-    allowEquip: true,
+    allowEquip: false,
     exclusive: false
   },
   {
@@ -612,7 +612,7 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
       quantity,
       showEquip: Boolean(config.allowEquip),
       exclusive: Boolean(config.exclusive),
-      equipped: Boolean(system.equipped),
+      equipped: config.allowEquip ? Boolean(system.equipped) : false,
       badges,
       summary,
       hasBadges: badges.length > 0,

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/Project_Andromeda/assets/Art_core_1.jpg"
     }
   ],
-  "version": "2.328",
+  "version": "2.329",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -621,6 +621,18 @@
                               />
                             </label>
                           {{/if}}
+                          {{#if item.canRoll}}
+                            <button
+                              type='button'
+                              class='item-roll item-control'
+                              data-item-id='{{item.id}}'
+                              data-group-key='{{item.groupKey}}'
+                              title='{{../../itemControls.roll}}'
+                            >
+                              <i class='fa-solid fa-dice-d10'></i>
+                              <span class='sr-only'>{{../../itemControls.roll}}</span>
+                            </button>
+                          {{/if}}
                           <button
                             type='button'
                             class='item-chat item-control'


### PR DESCRIPTION
## Summary
- add roll control for weapons in the inventory list so they can be rolled like other items
- remove weapon equip handling from item defaults, migrations, and UI configuration
- bump the system version to 2.329

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947fee30cd8832e86dc19e73dc960aa)