### PR TITLE
Use Body die for initiative; add 2d8/d20 ability dice; include full weapon properties in rolls

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1,5 +1,5 @@
 import { debugLog } from '../config.mjs';
-import { normalizeAbilityDie } from '../helpers/utils.mjs';
+import { getAbilityDieRoll, getAbilityDieNumeric, normalizeAbilityDie } from '../helpers/utils.mjs';
 
 /**
  * Extend the base Actor document by defining a custom roll data structure which is ideal for the Simple system.
@@ -23,6 +23,7 @@ export class ProjectAndromedaActor extends Actor {
     for (const a of Object.values(s.abilities ?? {})) {
       a.value = normalizeAbilityDie(a.value);
       a.mod = a.value; // «бонус» = само значение
+      a.roll = getAbilityDieRoll(a.value);
     }
 
     /* 2. Навыки ---------------------------------------------------- */
@@ -126,16 +127,12 @@ export class ProjectAndromedaActor extends Actor {
   }
 
   _getAbilityDefense(abilityValue) {
-    const defensesByDie = {
-      4: 2,
-      6: 3,
-      8: 4,
-      10: 6,
-      12: 8
-    };
-
-    const dieValue = normalizeAbilityDie(abilityValue);
-    return defensesByDie[dieValue] ?? 0;
+    const numeric = getAbilityDieNumeric(abilityValue);
+    if (numeric <= 4) return 2;
+    if (numeric <= 6) return 3;
+    if (numeric <= 8) return 4;
+    if (numeric <= 10) return 6;
+    return 8;
   }
 
   _computeItemTotals() {

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -7,7 +7,7 @@
  * @returns {number} Rank between 1 and 4
  */
 export function getColorRank(val = 0, type = 'skill') {
-  const numeric = Number(val) || 0;
+  const numeric = type === 'ability' ? getAbilityDieNumeric(val) : Number(val) || 0;
 
   if (type === 'ability') {
     if (numeric <= 6) return 1;
@@ -22,17 +22,61 @@ export function getColorRank(val = 0, type = 'skill') {
   return 4;
 }
 
-export const ABILITY_DIE_STEPS = [4, 6, 8, 10, 12];
+export const ABILITY_DIE_STEPS = [
+  { value: 4, label: 'd4', roll: '1d4', numeric: 4 },
+  { value: 6, label: 'd6', roll: '1d6', numeric: 6 },
+  { value: 8, label: 'd8', roll: '1d8', numeric: 8 },
+  { value: 10, label: 'd10', roll: '1d10', numeric: 10 },
+  { value: 12, label: 'd12', roll: '1d12', numeric: 12 },
+  { value: '2d8', label: '2d8', roll: '2d8', numeric: 16 },
+  { value: 20, label: 'd20', roll: '1d20', numeric: 20 }
+];
+
+const ABILITY_DIE_VALUES = ABILITY_DIE_STEPS.map((step) => step.value);
+const ABILITY_DIE_NUMERICS = ABILITY_DIE_STEPS.map((step) => step.numeric);
+
+export function getAbilityDieStep(value) {
+  if (value === undefined || value === null) return ABILITY_DIE_STEPS[0];
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase() : value;
+  const byValue = ABILITY_DIE_STEPS.find((step) => {
+    if (typeof normalized === 'number') return step.value === normalized;
+    if (typeof step.value === 'string' && typeof normalized === 'string') {
+      return step.value.toLowerCase() === normalized;
+    }
+    if (typeof normalized === 'string' && normalized.startsWith('d')) {
+      const numeric = Number(normalized.slice(1));
+      return Number.isFinite(numeric) && step.value === numeric;
+    }
+    return false;
+  });
+  if (byValue) return byValue;
+  if (typeof normalized === 'number') {
+    const min = Math.min(...ABILITY_DIE_NUMERICS);
+    const max = Math.max(...ABILITY_DIE_NUMERICS);
+    const clamped = Math.max(Math.min(normalized, max), min);
+    let closest = ABILITY_DIE_STEPS[0];
+    for (const step of ABILITY_DIE_STEPS) {
+      if (Math.abs(step.numeric - clamped) < Math.abs(closest.numeric - clamped)) {
+        closest = step;
+      }
+    }
+    return closest;
+  }
+  return ABILITY_DIE_STEPS[0];
+}
 
 export function normalizeAbilityDie(value) {
-  const numeric = Number(value);
-  if (ABILITY_DIE_STEPS.includes(numeric)) return numeric;
-  const clamped = Math.max(Math.min(numeric || 0, Math.max(...ABILITY_DIE_STEPS)), Math.min(...ABILITY_DIE_STEPS));
-  let closest = ABILITY_DIE_STEPS[0];
-  for (const die of ABILITY_DIE_STEPS) {
-    if (Math.abs(die - clamped) < Math.abs(closest - clamped)) {
-      closest = die;
-    }
-  }
-  return closest;
+  return getAbilityDieStep(value).value;
+}
+
+export function getAbilityDieLabel(value) {
+  return getAbilityDieStep(value).label;
+}
+
+export function getAbilityDieRoll(value) {
+  return getAbilityDieStep(value).roll;
+}
+
+export function getAbilityDieNumeric(value) {
+  return getAbilityDieStep(value).numeric;
 }

--- a/module/project-andromeda.mjs
+++ b/module/project-andromeda.mjs
@@ -40,8 +40,8 @@ Hooks.once('init', function () {
 
   // systems/project-andromeda/project-andromeda.mjs — в хуке init
   CONFIG.Combat.initiative = {
-    // Initiative rolls use d10 plus Body value
-    formula: '1d10 + @abilities.con.value',
+    // Initiative rolls use the Body die
+    formula: '@abilities.con.roll',
     decimals: 2
   };
 

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/Project_Andromeda/assets/Art_core_1.jpg"
     }
   ],
-  "version": "2.329",
+  "version": "2.330",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
### Motivation
- Initiative should use the actor's Body/`con` die instead of a fixed `1d10` plus a numeric value. 
- The fourth rank of ability dice must support two additional die options (`2d8` and `d20`) after `d12`. 
- Weapon chat/roll output should present full weapon properties (not only damage) when thrown or rolled. 
- Keep UI labels and derived calculations consistent with the new die types.

### Description
- Replaced the initiative formula in `module/project-andromeda.mjs` with the Body die roll string by using `@abilities.con.roll` for initiative calculation. 
- Extended ability die definitions in `module/helpers/utils.mjs` by replacing the simple array with `ABILITY_DIE_STEPS` entries that include `2d8` and `d20`, and added helpers `getAbilityDieStep`, `getAbilityDieLabel`, `getAbilityDieRoll`, `getAbilityDieNumeric` and updated `normalizeAbilityDie`/`getColorRank` to use them. 
- Populated derived actor data with an ability `roll` string via `getAbilityDieRoll` in `module/documents/actor.mjs` and updated `_getAbilityDefense` to use the die numeric for defense calculations. 
- Updated `module/sheets/actor-sheet.mjs` to display ability die labels, step through the new die list, and to use the die-specific roll formula when performing ability rolls, and changed weapon roll flavor to include full weapon details via the existing `_weaponEffectHtml` helper. 
- Bumped the package version in `system.json` to `2.330`.

### Testing
- No automated tests were executed for this change. 
- ESLint / CI checks were not run in this environment. 
- Runtime behavior was adjusted in code to use `getAbilityDieRoll` strings for rolls and `getAbilityDieNumeric` for numeric comparisons, but no automated unit tests were run to verify outcomes. 
- Manual verification in Foundry is recommended to confirm initiative, ability rolls, rank coloring and weapon chat output behave as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695008ae12a4832e8b5a040a8a78e9dc)