### PR TITLE
fix: prevent ability resets on skill edits

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -21,9 +21,9 @@ export class ProjectAndromedaActor extends Actor {
 
     /* 1. Способности ---------------------------------------------- */
     for (const a of Object.values(s.abilities ?? {})) {
-      a.value = normalizeAbilityDie(a.value);
-      a.mod = a.value; // «бонус» = само значение
-      a.roll = getAbilityDieRoll(a.value);
+      const normalized = normalizeAbilityDie(a.value);
+      a.mod = normalized; // «бонус» = само значение
+      a.roll = getAbilityDieRoll(normalized);
     }
 
     /* 2. Навыки ---------------------------------------------------- */

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/Project_Andromeda/assets/Art_core_1.jpg"
     }
   ],
-  "version": "2.330",
+  "version": "2.331",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
### Motivation
- Fix a bug where primary characteristics (abilities) were being reset when a skill was updated or when the character sheet was closed and reopened.
- The root cause was in-place mutation of stored ability values during derived-data preparation and using the live `actor.system` object for sheet rendering.
- Preserve stored data integrity and apply UI updates incrementally to avoid unnecessary full sheet re-renders.

### Description
- Stop mutating stored ability values in `module/documents/actor.mjs` by using a normalized local value for `mod` and `roll` instead of assigning back to `a.value`.
- Render sheet context from a safe copy by setting `context.system = foundry.utils.duplicate(actorData.system ?? {})` in `module/sheets/actor-sheet.mjs` to avoid side effects.
- Build per-ability display objects with normalized values (and labels/rank class/die label) instead of modifying underlying `system` entries, and update skill inputs to perform `await this.actor.update(..., { render: false })` while adjusting the rank CSS class in-place.
- Bump `system.json` version to `2.331` as part of the change set and make no localization string changes.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695013b998c4832e98df69ab2c8dd5e0)