### PR TITLE
fix: enable exclusive equips for weapons and correct equip handling

### DIFF
--- a/module/helpers/item-config.mjs
+++ b/module/helpers/item-config.mjs
@@ -245,8 +245,8 @@ export const ITEM_GROUP_CONFIGS = [
     createKey: 'MY_RPG.ItemGroups.CreateWeapon',
     newNameKey: 'MY_RPG.ItemGroups.NewWeapon',
     showQuantity: false,
-    allowEquip: false,
-    exclusive: false,
+    allowEquip: true,
+    exclusive: true,
     canRoll: true
   },
   {

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -885,7 +885,8 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
     const checked = Boolean(checkbox.checked);
     const updates = [{ _id: item.id, 'system.equipped': checked }];
     if (config.exclusive && checked) {
-      const others = this.actor.itemTypes?.[config.type] ?? [];
+      const groupType = config.types?.[0] ?? item.type;
+      const others = this.actor.itemTypes?.[groupType] ?? [];
       for (const other of others) {
         if (other.id === item.id) continue;
         if (other.system?.equipped) {

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.335",
+  "version": "2.336",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
### Motivation
- Allow weapons to be equipped from the character inventory and enforce that only one weapon or one armor can be equipped at a time.
- Ensure the equip toggle logic targets the proper item type group so exclusive equips correctly unequip other items in the same group.

### Description
- Enabled `allowEquip: true` and `exclusive: true` for the `weapons` item group in `module/helpers/item-config.mjs` so weapons show an equip checkbox and behave like armor. 
- Fixed exclusive-equip scanning in `ProjectAndromedaActorSheet._onItemEquipChange` to use the group type via `config.types?.[0] ?? item.type` and iterate `this.actor.itemTypes[groupType]` to find and unequip other items. 
- Kept updates batched to `this.actor.updateEmbeddedDocuments('Item', updates, { render: false })` and refresh derived data/UI afterward. 
- Bumped `system.json` version to `2.336` and did not add any new localisation strings. 

### Testing
- No automated tests were executed as part of this change (ESLint and CI were not run).
- Local commit and file changes were applied and staged successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976184aca30832eb1c8aeaee76c636a)