### PR TITLE
feat: group item types in create dialog by supertype

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -351,6 +351,12 @@
       "NewTraitTechnological": "New Technological Trait",
       "Unnamed": "Unnamed item"
     },
+    "ItemTypeGroups": {
+      "Equipment": "Equipment",
+      "Environment": "Environment",
+      "Traits": "Traits",
+      "Other": "Other"
+    },
     "ItemControls": {
       "Edit": "Edit",
       "Delete": "Delete",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -358,6 +358,12 @@
       "NewTraitTechnological": "Новая технологическая черта",
       "Unnamed": "Безымянный предмет"
     },
+    "ItemTypeGroups": {
+      "Equipment": "Экипировка",
+      "Environment": "Окружение",
+      "Traits": "Черты",
+      "Other": "Другое"
+    },
     "ItemControls": {
       "Edit": "Изменить",
       "Delete": "Удалить",

--- a/module/helpers/item-config.mjs
+++ b/module/helpers/item-config.mjs
@@ -7,6 +7,13 @@ export const ITEM_BASE_DEFAULTS = {
   details: {}
 };
 
+export const ITEM_SUPERTYPE_LABELS = {
+  equipment: 'MY_RPG.ItemTypeGroups.Equipment',
+  environment: 'MY_RPG.ItemTypeGroups.Environment',
+  traits: 'MY_RPG.ItemTypeGroups.Traits',
+  other: 'MY_RPG.ItemTypeGroups.Other'
+};
+
 export const ITEM_TYPE_CONFIGS = [
   {
     type: 'cartridge',

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.336",
+  "version": "2.337",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
### Motivation
- Make the Item Create dialog match the requested UI: show supertypes as non-selectable headers with selectable subtypes listed beneath.

### Description
- Add `ITEM_SUPERTYPE_LABELS` and use `ITEM_TYPE_CONFIGS` to group item types by `supertype` in `module/helpers/item-config.mjs` and `module/project-andromeda.mjs`.
- Introduce `buildItemTypeOptions` and a `renderItemCreateDialog` hook to replace the raw `select[name="type"]` options with grouped `<optgroup>` headers (supertypes) and subtype `<option>` entries, preserving the current selection when possible.
- Add localized labels for the new supertype headers in `lang/en.json` and `lang/ru.json` under `ItemTypeGroups` to ensure EN/RU parity.
- Bump `system.json` version from `2.336` to `2.337`.

### Testing
- No automated tests were executed in this change (ESLint/Jest were not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69761bf30558832eaa08bc31dc0bbaa7)