### PR TITLE
Group item types in create dialog with disabled supertype headings

### DIFF
--- a/css/project-andromeda.css
+++ b/css/project-andromeda.css
@@ -191,6 +191,12 @@ textarea[disabled] {
   font-weight: 700;
 }
 
+/* Item type selection ---------------------------------------------------- */
+.document-create-dialog select option.item-type-supertype {
+  font-weight: 700;
+  color: #1b1210;
+}
+
 /* Item sheets ---------------------------------------------------- */
 .project-andromeda.item-sheet {
   --item-sheet-border: #d4cbc0;

--- a/module/project-andromeda.mjs
+++ b/module/project-andromeda.mjs
@@ -38,18 +38,23 @@ function buildItemTypeOptions({ select, allowedTypes }) {
     if (!types?.length) continue;
     const labelKey = ITEM_SUPERTYPE_LABELS[groupKey];
     const label = labelKey ? game.i18n.localize(labelKey) : groupKey;
-    const $group = $(`<optgroup label="${label}"></optgroup>`);
+    const $heading = $(`<option class="item-type-supertype" disabled>${label}</option>`);
+    select.append($heading);
     for (const type of types) {
       const typeLabel = game.i18n.localize(`TYPES.Item.${type}`);
-      $group.append(`<option value="${type}">${typeLabel}</option>`);
+      select.append(`<option value="${type}">${typeLabel}</option>`);
     }
-    select.append($group);
   }
 
   if (currentValue && allowedTypes.has(currentValue)) {
     select.val(currentValue);
   } else {
-    select.prop('selectedIndex', 0);
+    const firstSelectable = select.find('option:not(:disabled)').first();
+    if (firstSelectable.length) {
+      select.val(firstSelectable.val());
+    } else {
+      select.prop('selectedIndex', 0);
+    }
   }
 }
 

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.338",
+  "version": "2.339",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
### Motivation
- The item creation dialog should display supertypes as bold, non-selectable headings with selectable subtypes listed below, because the previous grouping (using `<optgroup>`) did not meet the desired visual/behavior requirements.

### Description
- Update `buildItemTypeOptions` to insert a disabled `<option class="item-type-supertype">` for each supertype and append selectable subtype `<option value="...">` entries beneath it instead of using `<optgroup>`.
- Ensure the dialog selects a valid subtype by default by choosing the first non-disabled option when the previous value is not present.
- Add CSS rule `.document-create-dialog select option.item-type-supertype` to style supertype headings as bold and set their color.
- Bump the package version in `system.json` from `2.338` to `2.339`.

### Testing
- No automated tests were run against the modified code (ESLint/Jest were not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697624fe4aa4832ebbfe81e697eb73a8)