### PR TITLE
feat: remove wounds and add marked stress cells (left-click marks, right-click clears)

### DIFF
--- a/css/project-andromeda.css
+++ b/css/project-andromeda.css
@@ -43,16 +43,14 @@
   gap: 8px;
 }
 
-.stress-track,
-.wound-track {
+.stress-track {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
   justify-content: center;
 }
 
-.stress-cell,
-.wound-cell {
+.stress-cell {
   width: 26px;
   height: 26px;
   border-radius: 50%;
@@ -71,19 +69,17 @@
     color 0.15s ease;
 }
 
-.wound-cell {
-  font-weight: 600;
-  text-transform: uppercase;
-}
-
-.stress-cell.filled,
-.wound-cell.filled {
+.stress-cell.filled {
   background-color: #673e37;
   color: #d2d2c9;
 }
 
-.stress-cell:focus-visible,
-.wound-cell:focus-visible {
+.stress-cell.marked {
+  background-color: #87d0fb;
+  color: #1b1210;
+}
+
+.stress-cell:focus-visible {
   outline: 2px solid #0896e9;
   outline-offset: 2px;
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -124,15 +124,6 @@
       "Label": "Stress",
       "CellAria": "Stress point {index}"
     },
-    "Wounds": {
-      "Label": "Wounds",
-      "Minor": "Minor Wound",
-      "MinorAbbrev": "M",
-      "MinorAria": "Toggle minor wound",
-      "Severe": "Severe Wound",
-      "SevereAbbrev": "S",
-      "SevereAria": "Toggle severe wound"
-    },
     "ArmorItem": {
       "BonusPhysicalLabel": "Bonus to Physical Protection",
       "BonusMagicalLabel": "Bonus to Arcane Protection",
@@ -376,7 +367,6 @@
     "RollFlavor": {
       "Modifiers": "Modifiers",
       "SkillValue": "Skill ({skill})",
-      "WoundPenalty": "Wound penalty",
       "EquipmentBonus": "Equipment bonus",
       "Damage": "Damage {value}",
       "SourceWeapon": "Weapon: {name}",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -173,15 +173,6 @@
       "Label": "Стресс",
       "CellAria": "Клетка стресса {index}"
     },
-    "Wounds": {
-      "Label": "Раны",
-      "Minor": "Легкая рана",
-      "MinorAbbrev": "Л",
-      "MinorAria": "Переключить легкую рану",
-      "Severe": "Тяжелая рана",
-      "SevereAbbrev": "Т",
-      "SevereAria": "Переключить тяжелую рану"
-    },
     "Speed": {
       "Label": "Скорость передвижения"
     },
@@ -383,7 +374,6 @@
     "RollFlavor": {
       "Modifiers": "Модификаторы",
       "SkillValue": "Навык ({skill})",
-      "WoundPenalty": "Штраф за ранения",
       "EquipmentBonus": "Бонус экипировки",
       "Damage": "Урон {value}",
       "SourceWeapon": "Оружие: {name}",

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -42,14 +42,10 @@ export class ProjectAndromedaActor extends Actor {
     stress.value = Math.clamp
       ? Math.clamp(currentStress, 0, stress.max)
       : Math.min(Math.max(currentStress, 0), stress.max);
-
-    if (isCharacter) {
-      const wounds = s.wounds ?? (s.wounds = {});
-      wounds.minor = Boolean(wounds.minor);
-      wounds.severe = Boolean(wounds.severe);
-    } else if (isNpc && s.wounds !== undefined) {
-      delete s.wounds;
-    }
+    const marked = Array.isArray(stress.marked) ? stress.marked : [];
+    stress.marked = [...new Set(marked)]
+      .map((value) => Number(value))
+      .filter((value) => Number.isInteger(value) && value >= 0 && value < stress.max);
 
     s.flux ??= {};
     s.flux.value = this._calcFlux(s);

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -108,8 +108,10 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
     super.activateListeners(html);
     const $html = html instanceof jQuery ? html : $(html);
     $html.find('textarea.rich-editor').each((i, el) => this.initializeRichEditor(el));
-    $html.find('.stress-cell').on('click', this._onStressCellClick.bind(this));
-    $html.find('.wound-cell').on('click', this._onWoundCellClick.bind(this));
+    $html
+      .find('.stress-cell')
+      .on('click', this._onStressCellClick.bind(this))
+      .on('contextmenu', this._onStressCellRightClick.bind(this));
     $html.find('.rollable').on('click', this._onRoll.bind(this));
 
     $html.on('click', '.item-create', this._onItemCreate.bind(this));
@@ -206,8 +208,6 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
 
 
   _prepareCharacterData(context) {
-    const isCharacter = Boolean(context.isCharacter);
-    const isNpc = Boolean(context.isNpc);
     const abilityOrder = ['con', 'int', 'spi'];
     context.system.skills ??= {};
 
@@ -261,42 +261,18 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
     const stress = context.system.stress ?? { value: 0, max: 0 };
     const stressValue = Number(stress.value) || 0;
     const stressMax = Number(stress.max) || 0;
+    const marked = this._normalizeStressMarked(stress.marked, stressMax);
+    context.system.stress.marked = marked;
     context.system.stressTrack = Array.from({ length: Math.max(stressMax, 0) }, (_, index) => ({
       index,
       filled: index < stressValue,
+      marked: marked.includes(index),
       ariaLabel: game.i18n.format('MY_RPG.Stress.CellAria', { index: index + 1 })
     }));
-
-    if (isCharacter) {
-      const woundState = context.system.wounds ?? { minor: false, severe: false };
-      const woundDefs = [
-        {
-          type: 'minor',
-          labelKey: 'MY_RPG.Wounds.Minor',
-          abbrKey: 'MY_RPG.Wounds.MinorAbbrev',
-          ariaKey: 'MY_RPG.Wounds.MinorAria'
-        },
-        {
-          type: 'severe',
-          labelKey: 'MY_RPG.Wounds.Severe',
-          abbrKey: 'MY_RPG.Wounds.SevereAbbrev',
-          ariaKey: 'MY_RPG.Wounds.SevereAria'
-        }
-      ];
-      context.system.woundTrack = woundDefs.map((def) => ({
-        type: def.type,
-        labelKey: def.labelKey,
-        abbr: game.i18n.localize(def.abbrKey),
-        ariaLabel: game.i18n.localize(def.ariaKey),
-        filled: Boolean(woundState?.[def.type])
-      }));
-    } else if (isNpc) {
-      context.system.woundTrack = [];
-    }
   }
 
   /**
-   * Toggle stress and wound cells without forcing a full sheet re-render.
+   * Toggle stress cells without forcing a full sheet re-render.
    */
   async _onStressCellClick(event) {
     event.preventDefault();
@@ -308,27 +284,30 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
       index < current
         ? index
         : Math.min(index + 1, max);
-    await this.actor.update({ 'system.stress.value': next }, { render: false });
-    this._updateStressTrack(this.element, next);
+    const marked = this._normalizeStressMarked(stress.marked, max);
+    if (!marked.includes(index)) {
+      marked.push(index);
+    }
+    await this.actor.update(
+      {
+        'system.stress.value': next,
+        'system.stress.marked': marked
+      },
+      { render: false }
+    );
+    this._updateStressTrack(this.element, { value: next, marked: marked });
   }
 
-  async _onWoundCellClick(event) {
+  async _onStressCellRightClick(event) {
     event.preventDefault();
-    const type = event.currentTarget.dataset.type;
-    if (!type) return;
-    const current = Boolean(this.actor.system.wounds?.[type]);
-    const update = {};
-    update['system.wounds.' + type] = !current;
-    await this.actor.update(update, { render: false });
-    this._updateWoundTrack(this.element);
-  }
-
-  _getWoundPenalty() {
-    const wounds = this.actor.system.wounds || {};
-    let penalty = 0;
-    if (wounds.minor) penalty += 1;
-    if (wounds.severe) penalty += 2;
-    return penalty;
+    const index = Number(event.currentTarget.dataset.index) || 0;
+    const stress = this.actor.system.stress || { value: 0, max: 0 };
+    const max = Number(stress.max) || 0;
+    const marked = this._normalizeStressMarked(stress.marked, max).filter(
+      (cellIndex) => cellIndex !== index
+    );
+    await this.actor.update({ 'system.stress.marked': marked }, { render: false });
+    this._updateStressTrack(this.element, { marked: marked });
   }
 
   _stepAbilityDie(current, step) {
@@ -440,15 +419,6 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
       dieValue = dieValue ?? this._getAbilityDieValue(ability);
     }
 
-    const woundPenalty = this._getWoundPenalty();
-    if (woundPenalty) {
-      modifier -= woundPenalty;
-      parts.push({
-        label: game.i18n.localize('MY_RPG.RollFlavor.WoundPenalty'),
-        value: -woundPenalty
-      });
-    }
-
     const rollFormula = dieValue ? getAbilityDieRoll(dieValue) : getAbilityDieRoll(ABILITY_DIE_STEPS[0].value);
     const roll = await new Roll(`${rollFormula} + @mod`, { mod: modifier }).roll({
       async: true
@@ -462,7 +432,7 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
   }
 
   /**
-   * Update derived fields on the sheet (speed, defenses, stress and wounds)
+   * Update derived fields on the sheet (speed, defenses, stress)
    * after an in-place change without re-rendering the sheet.
    */
   _refreshDerived(html) {
@@ -480,34 +450,39 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
     setVal('system.defenses.mental', s?.defenses?.mental);
 
     this._updateStressTrack($root);
-    this._updateWoundTrack($root);
   }
 
-  _updateStressTrack(root, explicitValue) {
+  _updateStressTrack(root, options = {}) {
     const $root = root instanceof jQuery ? root : $(root ?? this.element);
     const stress = this.actor.system.stress || { value: 0, max: 0 };
     const value =
-      typeof explicitValue === 'number' ? explicitValue : Number(stress.value) || 0;
+      typeof options === 'number'
+        ? options
+        : typeof options?.value === 'number'
+          ? options.value
+          : Number(stress.value) || 0;
+    const marked = Array.isArray(options?.marked)
+      ? this._normalizeStressMarked(options.marked, Number(stress.max) || 0)
+      : this._normalizeStressMarked(stress.marked, Number(stress.max) || 0);
     const $track = $root.find('.stress-track');
     if (!$track.length) return;
     $track.find('.stress-cell').each((i, el) => {
       const filled = i < value;
+      const isMarked = marked.includes(i);
       el.classList.toggle('filled', filled);
+      el.classList.toggle('marked', isMarked);
       el.setAttribute('aria-pressed', filled ? 'true' : 'false');
     });
   }
 
-  _updateWoundTrack(root) {
-    const $root = root instanceof jQuery ? root : $(root ?? this.element);
-    const wounds = this.actor.system.wounds || { minor: false, severe: false };
-    const $track = $root.find('.wound-track');
-    if (!$track.length) return;
-    $track.find('.wound-cell').each((_, el) => {
-      const type = el.dataset.type;
-      const filled = Boolean(wounds?.[type]);
-      el.classList.toggle('filled', filled);
-      el.setAttribute('aria-pressed', filled ? 'true' : 'false');
-    });
+  _normalizeStressMarked(marked, max) {
+    const limit = Number.isFinite(max) ? max : null;
+    const source = Array.isArray(marked) ? marked : [];
+    const normalized = source
+      .map((value) => Number(value))
+      .filter((value) =>
+        Number.isInteger(value) && value >= 0 && (limit === null || value < limit));
+    return [...new Set(normalized)];
   }
 
   _getItemControlLabels() {

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.337",
+  "version": "2.338",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/template.json
+++ b/template.json
@@ -24,7 +24,8 @@
         "inventoryList": [],
         "stress": {
           "value": 0,
-          "max": 4
+          "max": 4,
+          "marked": []
         },
         "flux": {
           "value": 0
@@ -105,10 +106,6 @@
     },
     "character": {
       "templates": ["base"],
-      "wounds": {
-        "minor": false,
-        "severe": false
-      },
       "biography": {
         "weight": "",
         "height": "",

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -166,7 +166,7 @@
                   {{#each system.stressTrack as |cell|}}
                     <button
                       type='button'
-                      class='stress-cell {{#if cell.filled}}filled{{/if}}'
+                      class='stress-cell {{#if cell.filled}}filled{{/if}} {{#if cell.marked}}marked{{/if}}'
                       data-index='{{cell.index}}'
                       aria-label='{{cell.ariaLabel}}'
                       aria-pressed='{{#if cell.filled}}true{{else}}false{{/if}}'
@@ -175,27 +175,6 @@
                 </div>
               </div>
             </div>
-            {{#if system.woundTrack.length}}
-              <div class='resource flex-group-center'>
-                <label class='resource-label'>{{localize 'MY_RPG.Wounds.Label'}}</label>
-                <div class='resource-content flexcol'>
-                  <div class='wound-track'>
-                    {{#each system.woundTrack as |cell|}}
-                      <button
-                        type='button'
-                        class='wound-cell {{cell.type}} {{#if cell.filled}}filled{{/if}}'
-                        data-type='{{cell.type}}'
-                        aria-label='{{cell.ariaLabel}}'
-                        title='{{localize cell.labelKey}}'
-                        aria-pressed='{{#if cell.filled}}true{{else}}false{{/if}}'
-                      >
-                        {{cell.abbr}}
-                      </button>
-                    {{/each}}
-                  </div>
-                </div>
-              </div>
-            {{/if}}
           </section>
 
 


### PR DESCRIPTION
### Motivation
- Simplify the health model by removing the separate wounds mechanic and its gameplay penalties, and keep only the stress track as the resource for damage/strain. 
- Add a visual, persistent "marked" state to individual stress cells so clicks can both update stress value and flag cells (light-blue) without forcing a full sheet re-render. 
- Preserve incremental in-place UI updates and data normalization for actor state while keeping localization parity and auto-bumping the system version. 

### Description
- Removed wound state and UI: wound fields were removed from `template.json`, wound-related UI and handlers were deleted from `templates/actor/actor-character-sheet.hbs` and `module/sheets/actor-sheet.mjs`, and wound localization keys were removed from `lang/en.json` and `lang/ru.json`. 
- Introduced a `marked` stress state: `system.stress.marked` is normalized in `module/documents/actor.mjs` and the template default was updated in `template.json`. 
- Stress cell behavior and persistence: sheet listeners now attach a `click` handler to left-click a stress cell (updates `system.stress.value` and adds the cell index to `system.stress.marked`) and a `contextmenu` handler for right-click to remove the index from `system.stress.marked`, with in-place UI updates in `_updateStressTrack` in `module/sheets/actor-sheet.mjs`. 
- Visual styling: added `.stress-cell.marked` style to `css/project-andromeda.css` to show a light-blue mark while preserving the dark filled state for stressed cells. 
- Roll logic: wound-penalty contributions were removed from roll flavor construction and roll modifier application. 
- Version bump: incremented `system.json` version from `2.337` to `2.338`. 

### Testing
- No automated tests (ESLint/Jest) were executed as part of this change. 
- Basic static changes were validated by code inspection and repository searches for removed/updated symbols (no runtime Foundry UI tests were run). 
- Commit was created and changes staged successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697624496220832ea1ee5ecfe69b17db)