### PR TITLE
fix: align stress track click behavior

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -284,18 +284,13 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
       index < current
         ? index
         : Math.min(index + 1, max);
-    const marked = this._normalizeStressMarked(stress.marked, max);
-    if (!marked.includes(index)) {
-      marked.push(index);
-    }
     await this.actor.update(
       {
-        'system.stress.value': next,
-        'system.stress.marked': marked
+        'system.stress.value': next
       },
       { render: false }
     );
-    this._updateStressTrack(this.element, { value: next, marked: marked });
+    this._updateStressTrack(this.element, { value: next });
   }
 
   async _onStressCellRightClick(event) {
@@ -303,9 +298,10 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
     const index = Number(event.currentTarget.dataset.index) || 0;
     const stress = this.actor.system.stress || { value: 0, max: 0 };
     const max = Number(stress.max) || 0;
-    const marked = this._normalizeStressMarked(stress.marked, max).filter(
-      (cellIndex) => cellIndex !== index
-    );
+    const normalizedMarked = this._normalizeStressMarked(stress.marked, max);
+    const marked = normalizedMarked.includes(index)
+      ? normalizedMarked.filter((cellIndex) => cellIndex < index)
+      : Array.from({ length: index + 1 }, (_, cellIndex) => cellIndex);
     await this.actor.update({ 'system.stress.marked': marked }, { render: false });
     this._updateStressTrack(this.element, { marked: marked });
   }

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.339",
+  "version": "2.340",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
### Motivation
- Improve UX consistency for the stress track so left-clicking only changes the filled value while right-clicking toggles marked ranges.
- Prevent accidental mutation of the marked cells array during normal left-click interactions.

### Description
- Left-click handler `_onStressCellClick` no longer mutates `system.stress.marked` and now updates only `system.stress.value` with `render: false` and refreshes the track with `{ value: next }`.
- Right-click handler `_onStressCellRightClick` now normalizes the existing marked cells and toggles a marked range: if the clicked index is present it truncates marks to indices `< index`, otherwise it marks the full range `0..index` before updating `system.stress.marked` with `render: false`.
- Updated calls to `_updateStressTrack` to pass only the changed data (`value` or `marked`) to avoid full sheet re-renders.
- Bumped `system.json` version from `2.339` to `2.340` to follow the repository versioning rule.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69762a606b58832ea90f3163356123c0)