### PR TITLE
feat: add genome and source-ability item types/groups with localization

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -268,6 +268,14 @@
       "EmptyImplants": "No implants yet.",
       "CreateImplant": "Add implant",
       "NewImplant": "New Implant",
+      "Genomes": "Genomes",
+      "EmptyGenomes": "No genomes yet.",
+      "CreateGenome": "Add genome",
+      "NewGenome": "New Genome",
+      "SourceAbilities": "Source Abilities",
+      "EmptySourceAbilities": "No source abilities yet.",
+      "CreateSourceAbility": "Add source ability",
+      "NewSourceAbility": "New Source Ability",
       "Weapons": "Weapons",
       "EmptyWeapons": "No weapons yet.",
       "CreateWeapon": "Add weapon",
@@ -420,7 +428,9 @@
       "trait-combat": "Combat Trait",
       "trait-magical": "Magical Trait",
       "trait-professional": "Professional Trait",
-      "trait-technological": "Technological Trait"
+      "trait-technological": "Technological Trait",
+      "trait-genome": "Genome",
+      "trait-source-ability": "Source Ability"
     }
   }
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -275,6 +275,14 @@
       "EmptyImplants": "Пока нет имплантов.",
       "CreateImplant": "Добавить имплант",
       "NewImplant": "Новый имплант",
+      "Genomes": "Геномы",
+      "EmptyGenomes": "Пока нет геномов.",
+      "CreateGenome": "Добавить геном",
+      "NewGenome": "Новый геном",
+      "SourceAbilities": "Способности источника",
+      "EmptySourceAbilities": "Пока нет способностей источника.",
+      "CreateSourceAbility": "Добавить способность источника",
+      "NewSourceAbility": "Новая способность источника",
       "Weapons": "Оружие",
       "EmptyWeapons": "Пока нет оружия.",
       "CreateWeapon": "Добавить оружие",
@@ -427,7 +435,9 @@
       "trait-combat": "Боевая черта",
       "trait-magical": "Магическая черта",
       "trait-professional": "Профессиональная черта",
-      "trait-technological": "Технологическая черта"
+      "trait-technological": "Технологическая черта",
+      "trait-genome": "Геном",
+      "trait-source-ability": "Способность источника"
     }
   }
 }

--- a/module/helpers/item-config.mjs
+++ b/module/helpers/item-config.mjs
@@ -210,6 +210,18 @@ export const ITEM_TYPE_CONFIGS = [
     supertype: 'traits',
     groupKey: 'traitTechnological',
     sheet: 'generic'
+  },
+  {
+    type: 'trait-genome',
+    supertype: 'traits',
+    groupKey: 'genomes',
+    sheet: 'generic'
+  },
+  {
+    type: 'trait-source-ability',
+    supertype: 'traits',
+    groupKey: 'sourceAbilities',
+    sheet: 'generic'
   }
 ];
 
@@ -241,6 +253,34 @@ export const ITEM_GROUP_CONFIGS = [
     allowEquip: false,
     exclusive: false,
     canRoll: true
+  },
+  {
+    key: 'genomes',
+    types: ['trait-genome'],
+    tab: 'abilities',
+    icon: 'fas fa-dna',
+    labelKey: 'MY_RPG.ItemGroups.Genomes',
+    emptyKey: 'MY_RPG.ItemGroups.EmptyGenomes',
+    createKey: 'MY_RPG.ItemGroups.CreateGenome',
+    newNameKey: 'MY_RPG.ItemGroups.NewGenome',
+    showQuantity: false,
+    allowEquip: false,
+    exclusive: false,
+    canRoll: false
+  },
+  {
+    key: 'sourceAbilities',
+    types: ['trait-source-ability'],
+    tab: 'abilities',
+    icon: 'fas fa-bolt',
+    labelKey: 'MY_RPG.ItemGroups.SourceAbilities',
+    emptyKey: 'MY_RPG.ItemGroups.EmptySourceAbilities',
+    createKey: 'MY_RPG.ItemGroups.CreateSourceAbility',
+    newNameKey: 'MY_RPG.ItemGroups.NewSourceAbility',
+    showQuantity: false,
+    allowEquip: false,
+    exclusive: false,
+    canRoll: false
   },
   {
     key: 'weapons',

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.339",
+  "version": "2.340",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
### Motivation
- Add two new item types to represent character genomes and source abilities and expose them in the UI as separate groups. 
- Provide English and Russian localization for the new groups and item type labels and bump the package version.

### Description
- Added two new `ITEM_TYPE_CONFIGS` entries in `module/helpers/item-config.mjs` for `trait-genome` and `trait-source-ability` with `supertype: 'traits'` and `sheet: 'generic'`.
- Added two new `ITEM_GROUP_CONFIGS` entries (`genomes` and `sourceAbilities`) in `module/helpers/item-config.mjs` with `tab: 'abilities'`, so these groups are shown on the Abilities tab rather than in the traits tab, ensuring the unified traits listing does not include `trait-source-ability`.
- Added localization keys for the new item groups and the `TYPES.Item.trait-genome` and `TYPES.Item.trait-source-ability` entries in both `lang/en.json` and `lang/ru.json`.
- Bumped `system.json` version from `2.339` to `2.340`.

### Testing
- No automated tests were executed as part of this change.
- Verified files updated: `module/helpers/item-config.mjs`, `lang/en.json`, `lang/ru.json`, and `system.json` and confirmed localization parity for both languages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69762de94f44832e911a7ebb136bba2e)