### PR TITLE
fix: move implants to inventory tab

### DIFF
--- a/module/helpers/item-config.mjs
+++ b/module/helpers/item-config.mjs
@@ -231,7 +231,7 @@ export const ITEM_GROUP_CONFIGS = [
   {
     key: 'implants',
     types: ['implant'],
-    tab: 'abilities',
+    tab: 'inventory',
     icon: 'fas fa-cogs',
     labelKey: 'MY_RPG.ItemGroups.Implants',
     emptyKey: 'MY_RPG.ItemGroups.EmptyImplants',

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.339",
+  "version": "2.340",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
### Motivation
- Place the `implants` item group under the character `inventory` tab so implants appear alongside other equipment groups in the sheet.

### Description
- Updated `module/helpers/item-config.mjs` to change the `implants` group's `tab` from `abilities` to `inventory`, confirmed `templates/actor/actor-character-sheet.hbs` uses the generic group renderer via `{{#each (lookup ../itemGroups tab.key) as |group|}}` so implants will render automatically, and bumped `system.json` version to `2.340`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69762de73948832eb649af1dc620473d)