### PR TITLE
Update sheet labels to “Abilities and Genomes” and bump version

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -72,10 +72,10 @@
       "PsychicLabel": "Mental Protection"
     },
     "SheetLabels": {
-      "AbilitiesAndMods": "Cartridges and Implants",
+      "AbilitiesAndMods": "Abilities and Genomes",
       "Tablet": "Tablet",
       "Features": "Main Sheet",
-      "Abilities": "Cartridges",
+      "Abilities": "Genomes",
       "Parameters": "Parameters",
       "Attributes": "Attributes",
       "Skills": "Skills",
@@ -84,7 +84,7 @@
       "Inventory": "Inventory",
       "Environment": "Environment",
       "Traits": "Traits",
-      "ItemAbility": "Cartridge Sheet",
+      "ItemAbility": "Genome Sheet",
       "ItemMod": "Implant Sheet",
       "ItemArmor": "Armor Sheet",
       "ItemWeapon": "Weapon Sheet",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -97,10 +97,10 @@
       "MomentOfGlory": "Миг Славы"
     },
     "SheetLabels": {
-      "AbilitiesAndMods": "Картриджи и импланты",
+      "AbilitiesAndMods": "Способности и геномы",
       "Tablet": "Скрижаль",
       "Features": "Основной лист",
-      "Abilities": "Картриджи",
+      "Abilities": "Геномы",
       "Parameters": "Параметры",
       "Attributes": "Характеристики",
       "Skills": "Навыки",
@@ -109,7 +109,7 @@
       "Inventory": "Инвентарь",
       "Environment": "Окружение",
       "Traits": "Черты",
-      "ItemAbility": "Лист картриджа",
+      "ItemAbility": "Лист генома",
       "ItemMod": "Лист импланта",
       "ItemArmor": "Лист доспеха",
       "ItemWeapon": "Лист оружия",

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.339",
+  "version": "2.340",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
### Motivation
- Rename cartridge-centric UI text to the new terminology so the character sheet shows “Abilities and Genomes” consistently in both languages.

### Description
- Update English localization in `lang/en.json` for `MY_RPG.SheetLabels.AbilitiesAndMods`, `MY_RPG.SheetLabels.Abilities`, and `MY_RPG.SheetLabels.ItemAbility` to use "Abilities and Genomes" / "Genomes" / "Genome Sheet".
- Update Russian localization in `lang/ru.json` with matching keys (`MY_RPG.SheetLabels.AbilitiesAndMods`, `MY_RPG.SheetLabels.Abilities`, `MY_RPG.SheetLabels.ItemAbility`) to the accurate Russian equivalents.
- Bump package manifest `version` in `system.json` from `2.339` to `2.340` to follow the repository versioning rule.

### Testing
- No automated tests were executed in this change; CI is expected to run linting and JSON schema checks after the merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69762de67290832eaea344a9b2aab488)