### PR TITLE
Remove cartridge group and rune-size UI from actor sheet

### DIFF
--- a/module/helpers/item-config.mjs
+++ b/module/helpers/item-config.mjs
@@ -215,20 +215,6 @@ export const ITEM_TYPE_CONFIGS = [
 
 export const ITEM_GROUP_CONFIGS = [
   {
-    key: 'cartridges',
-    types: ['cartridge'],
-    tab: 'abilities',
-    icon: 'fas fa-magic',
-    labelKey: 'MY_RPG.ItemGroups.Cartridges',
-    emptyKey: 'MY_RPG.ItemGroups.EmptyCartridges',
-    createKey: 'MY_RPG.ItemGroups.CreateCartridge',
-    newNameKey: 'MY_RPG.ItemGroups.NewCartridge',
-    showQuantity: false,
-    allowEquip: false,
-    exclusive: false,
-    canRoll: true
-  },
-  {
     key: 'implants',
     types: ['implant'],
     tab: 'abilities',
@@ -557,24 +543,6 @@ export function getItemTabLabel(tabKey, worldType) {
 }
 
 export const ITEM_BADGE_BUILDERS = {
-  cartridges: (item, helpers) => {
-    const system = item.system ?? {};
-    const badges = [];
-    const t = helpers.t;
-    const rank = Number(system.rank) || 0;
-    if (rank) {
-      badges.push(`${t.localize('MY_RPG.AbilitiesTable.Rank')}: ${helpers.getRankLabel(rank)}`);
-    }
-    if (helpers.worldType === 'unity' && system.runeType) {
-      const runeKey = `MY_RPG.RuneTypes.${system.runeType}`;
-      badges.push(`${t.localize('MY_RPG.RunesTable.RuneType')}: ${t.localize(runeKey)}`);
-    }
-    badges.push(`${t.localize('MY_RPG.AbilitiesTable.Skill')}: ${helpers.skillLabel(system.skill)}`);
-    badges.push(
-      `${t.localize('MY_RPG.AbilitiesTable.Bonus')}: ${helpers.formatSkillBonus(system.skillBonus)}`
-    );
-    return badges;
-  },
   implants: (item, helpers) => {
     const system = item.system ?? {};
     const badges = [];

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -176,9 +176,6 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
     }
 
     const worldType = game.settings.get(MODULE_ID, 'worldType');
-    if (worldType === 'unity') {
-      context.runeMax = (Number(context.system.abilities.int?.value || 0) * 2) + 5;
-    }
 
     context.rollData = context.actor.getRollData();
     context.itemTabs = ITEM_TABS.map((tab) => ({
@@ -187,16 +184,6 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
     }));
 
     const itemGroups = this._buildItemGroups();
-    const cartridgeGroup = itemGroups.find((group) => group.key === 'cartridges');
-    if (cartridgeGroup) {
-      cartridgeGroup.capacity = worldType === 'unity'
-        ? { value: cartridgeGroup.count, max: context.runeMax ?? 0 }
-        : null;
-      context.cartridgeCount = cartridgeGroup.count;
-    } else {
-      context.cartridgeCount = 0;
-    }
-
     context.itemGroups = itemGroups.reduce((acc, group) => {
       (acc[group.tab] ??= []).push(group);
       return acc;

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.339",
+  "version": "2.340",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -385,16 +385,6 @@
 
       {{#each itemTabs as |tab|}}
         <div class='tab {{tab.key}}' data-group='primary' data-tab='{{tab.key}}'>
-          {{#isTab tab.key 'abilities'}}
-            {{#ifUnity}}
-            <div class='rune-size'>
-              <label>{{localize 'MY_RPG.RunesTable.SizeLabel'}}</label>
-              <input type='number' value='{{../cartridgeCount}}' disabled />
-              <span class='divider'>/</span>
-              <input type='number' value='{{../runeMax}}' disabled />
-            </div>
-            {{/ifUnity}}
-          {{/isTab}}
           <section class='item-groups' data-groups='{{tab.key}}'>
             {{#each (lookup ../itemGroups tab.key) as |group|}}
               <section class='item-group' data-item-group='{{group.key}}'>


### PR DESCRIPTION
### Motivation
- The actor sheet should no longer render cartridge-specific UI (cartridge counts / rune size) in the abilities tab to simplify the sheet and avoid showing cartridge-only mechanics on actors.
- Cartridge badge and group logic that only applied to actor rendering should be removed to prevent unused/duplicated UI code on the sheet.
- Keep cartridge item type and its item sheet intact for legacy or item-level usage while removing actor-level display plumbing.

### Description
- Removed the `cartridges` entry from `ITEM_GROUP_CONFIGS` in `module/helpers/item-config.mjs` so the cartridge group is no longer built for actor sheets.
- Removed the `cartridges` entry from `ITEM_BADGE_BUILDERS` in `module/helpers/item-config.mjs` so cartridge-specific badge generation is not used on actor sheets.
- Removed rune/cartridge count and `runeMax` calculations and cartridge-group capacity handling from `getData()` in `module/sheets/actor-sheet.mjs` so the actor context no longer exposes `cartridgeCount`/`runeMax` or sets group capacity.
- Deleted the `rune-size` UI block from `templates/actor/actor-character-sheet.hbs` to stop rendering the cartridge/rune size inputs in the abilities tab, and bumped `system.json` version to `2.340`.
- Cartridge item type and item sheet/template remain unchanged so cartridges continue to function as items outside actor-group rendering.

### Testing
- No automated tests were run for this change (ESLint / Jest / CI were not executed locally).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69762de6cd84832e82cd473d26a5a0ce)