### PR TITLE
fix: remove environment tab from character sheet

### DIFF
--- a/module/helpers/item-config.mjs
+++ b/module/helpers/item-config.mjs
@@ -564,10 +564,6 @@ export const ITEM_TABS = [
   {
     key: 'inventory',
     labelKey: 'MY_RPG.SheetLabels.Inventory'
-  },
-  {
-    key: 'environment',
-    labelKey: 'MY_RPG.SheetLabels.Environment'
   }
 ];
 

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.341",
+  "version": "2.342",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
### Motivation
- The environment item tab is not needed on character sheets because environment items are kept in the system for use on tactical maps, so the tab should be hidden while leaving items intact.

### Description
- Remove the `environment` entry from `ITEM_TABS` in `module/helpers/item-config.mjs` so the tab no longer appears on character sheets and bump the system version in `system.json` to `2.342`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697630fbf0dc832ebcc301d10630fbdf)