### PR TITLE
fix: register genome and source-ability item types

### DIFF
--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.342",
+  "version": "2.343",
   "compatibility": {
     "minimum": "12",
     "verified": "12"

--- a/template.json
+++ b/template.json
@@ -152,7 +152,9 @@
       "trait-combat",
       "trait-magical",
       "trait-professional",
-      "trait-technological"
+      "trait-technological",
+      "trait-genome",
+      "trait-source-ability"
     ],
     "templates": {
       "base": {
@@ -243,6 +245,12 @@
       "templates": ["base"]
     },
     "trait-technological": {
+      "templates": ["base"]
+    },
+    "trait-genome": {
+      "templates": ["base"]
+    },
+    "trait-source-ability": {
       "templates": ["base"]
     }
   }


### PR DESCRIPTION
### Motivation
- Foundry reported `type: “trait-source-ability” is not a valid type for the Item Document class`, so the system template must register the `trait-genome` and `trait-source-ability` item types so they are valid Item document types.

### Description
- Added `trait-genome` and `trait-source-ability` to the `Item.types` list and their base templates in `template.json`, and bumped the system `version` in `system.json` from `2.342` to `2.343`.

### Testing
- No automated tests were run for this change (ESLint/Jest not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697646956470832ebdfaafbea56239a6)