### PR TITLE
fix: group item types with optgroups

### DIFF
--- a/css/project-andromeda.css
+++ b/css/project-andromeda.css
@@ -188,7 +188,7 @@ textarea[disabled] {
 }
 
 /* Item type selection ---------------------------------------------------- */
-.document-create-dialog select option.item-type-supertype {
+.document-create-dialog select optgroup {
   font-weight: 700;
   color: #1b1210;
 }

--- a/module/project-andromeda.mjs
+++ b/module/project-andromeda.mjs
@@ -38,12 +38,12 @@ function buildItemTypeOptions({ select, allowedTypes }) {
     if (!types?.length) continue;
     const labelKey = ITEM_SUPERTYPE_LABELS[groupKey];
     const label = labelKey ? game.i18n.localize(labelKey) : groupKey;
-    const $heading = $(`<option class="item-type-supertype" disabled>${label}</option>`);
-    select.append($heading);
+    const $group = $(`<optgroup label="${label}"></optgroup>`);
     for (const type of types) {
       const typeLabel = game.i18n.localize(`TYPES.Item.${type}`);
-      select.append(`<option value="${type}">${typeLabel}</option>`);
+      $group.append(`<option value="${type}">${typeLabel}</option>`);
     }
+    select.append($group);
   }
 
   if (currentValue && allowedTypes.has(currentValue)) {

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.343",
+  "version": "2.344",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
### Motivation
- The create-item dialog previously used disabled `<option>` rows as headings, which did not semantically group subtypes or render consistent headers for each supertype.
- Render supertype headers as real groupings to improve accessibility, styling, and UX consistency.

### Description
- Replace disabled heading options with `<optgroup>` elements in `module/project-andromeda.mjs` so subtypes are grouped under their supertype.
- Append subtype `<option>` elements into the created `<optgroup>` and append the group to the select instead of inserting a disabled option.
- Update the stylesheet selector from `.document-create-dialog select option.item-type-supertype` to `.document-create-dialog select optgroup` in `css/project-andromeda.css` to target group labels.
- Bump the system manifest version to `2.344` in `system.json` to follow the repository auto-bump rule.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977d34231f0832ea2e032521540e976)