### PR TITLE
fix: rebuild item type optgroups via DOM

### DIFF
--- a/css/project-andromeda.css
+++ b/css/project-andromeda.css
@@ -188,7 +188,7 @@ textarea[disabled] {
 }
 
 /* Item type selection ---------------------------------------------------- */
-.document-create-dialog select option.item-type-supertype {
+.document-create-dialog select optgroup {
   font-weight: 700;
   color: #1b1210;
 }

--- a/module/project-andromeda.mjs
+++ b/module/project-andromeda.mjs
@@ -14,6 +14,8 @@ import './helpers/handlebars-helpers.mjs';
 const ITEM_SUPERTYPE_ORDER = ['equipment', 'environment', 'traits', 'other'];
 
 function buildItemTypeOptions({ select, allowedTypes }) {
+  const selectElement = select.get(0);
+  if (!selectElement) return;
   const currentValue = select.val();
   const grouped = new Map();
   const unknownTypes = new Set(allowedTypes);
@@ -31,29 +33,35 @@ function buildItemTypeOptions({ select, allowedTypes }) {
     grouped.set('other', [...(grouped.get('other') ?? []), ...unknownTypes]);
   }
 
-  select.empty();
+  const fragment = document.createDocumentFragment();
 
   for (const groupKey of ITEM_SUPERTYPE_ORDER) {
     const types = grouped.get(groupKey);
     if (!types?.length) continue;
     const labelKey = ITEM_SUPERTYPE_LABELS[groupKey];
     const label = labelKey ? game.i18n.localize(labelKey) : groupKey;
-    const $heading = $(`<option class="item-type-supertype" disabled>${label}</option>`);
-    select.append($heading);
+    const groupElement = document.createElement('optgroup');
+    groupElement.label = label;
     for (const type of types) {
       const typeLabel = game.i18n.localize(`TYPES.Item.${type}`);
-      select.append(`<option value="${type}">${typeLabel}</option>`);
+      const option = document.createElement('option');
+      option.value = type;
+      option.textContent = typeLabel;
+      groupElement.append(option);
     }
+    fragment.append(groupElement);
   }
 
+  selectElement.replaceChildren(fragment);
+
   if (currentValue && allowedTypes.has(currentValue)) {
-    select.val(currentValue);
+    selectElement.value = currentValue;
   } else {
-    const firstSelectable = select.find('option:not(:disabled)').first();
-    if (firstSelectable.length) {
-      select.val(firstSelectable.val());
+    const firstSelectable = selectElement.querySelector('option:not(:disabled)');
+    if (firstSelectable) {
+      selectElement.value = firstSelectable.value;
     } else {
-      select.prop('selectedIndex', 0);
+      selectElement.selectedIndex = 0;
     }
   }
 }

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.343",
+  "version": "2.345",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
### Motivation
- Ensure the item type `<select>` uses proper `optgroup` semantics for accessibility and consistent rendering instead of disabled heading `<option>` rows.
- Preserve the current selection and fallback behavior after rebuilding options and make the routine resilient when the jQuery selection has no underlying DOM element (`select.get(0)`).

### Description
- Replace string-based jQuery option assembly with native DOM creation by building a `DocumentFragment` of `optgroup` and `option` elements and calling `selectElement.replaceChildren(fragment)`.
- Capture the current value before replacement and restore it using the native `value` property, otherwise fall back to the first selectable `option` or set `selectedIndex = 0` if none exist.
- Add an early return when `select.get(0)` is not present to avoid runtime errors and bump `system.json` version to `2.345`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977d34231f0832ea2e032521540e976)