### PR TITLE
fix: use dialog's documentTypes when building item type groups

### DIFF
--- a/module/project-andromeda.mjs
+++ b/module/project-andromeda.mjs
@@ -131,7 +131,7 @@ Hooks.once('init', function () {
     if (app?.documentName !== 'Item') return;
     const select = html.find('select[name="type"]');
     if (!select?.length) return;
-    const allowedTypes = new Set(game.system.documentTypes?.Item ?? []);
+    const allowedTypes = new Set(app?.documentTypes?.Item ?? game.documentTypes?.Item ?? []);
     if (!allowedTypes.size) return;
     buildItemTypeOptions({ select, allowedTypes });
   });

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.345",
+  "version": "2.346",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
### Motivation
- The item create dialog could fail to build grouped `optgroup` options because available Item types were being read from `game.system.documentTypes`, which may be unavailable in the dialog context.

### Description
- Change the `renderDocumentCreateDialog` handler to read allowed types from `app?.documentTypes?.Item` with a fallback to `game.documentTypes?.Item`, and pass that set to `buildItemTypeOptions`; also bump the package `version` in `system.json` to `2.346`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977de290e6c832e82bf87a96707ccf2)