### PR TITLE
fix: prevent weapon roll debug crash

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -796,8 +796,7 @@ export class ProjectAndromedaActorSheet extends ActorSheet {
         type: item.type,
         skill: skillKey,
         skillValue,
-        modifier,
-        damage: damageValue
+        modifier
       });
     }
   }

--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.346",
+  "version": "2.347",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
### Motivation
- Prevent a runtime exception in `_onItemRoll` when handling weapon rolls due to an undefined `damageValue` in the debug payload. 
- Ensure weapon roll flow completes without exceptions and follow repository policy to bump `system.json` version on code changes.

### Description
- Remove the `damage: damageValue` property from the `debugLog` payload in the weapon branch of `_onItemRoll` to avoid referencing an undefined variable. 
- Bump `system.json` version from `2.346` to `2.347` as required by repository guidelines. 
- No localization or user-facing strings were added or modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978aafe3400832e95ff8f0f4578979f)