### PR TITLE
fix: rebuild item-type optgroups using Foundry helper

### DIFF
--- a/system.json
+++ b/system.json
@@ -16,7 +16,7 @@
       "thumbnail": "systems/project-andromeda/assets/Art_core_1.webp"
     }
   ],
-  "version": "2.347",
+  "version": "2.348",
   "compatibility": {
     "minimum": "12",
     "verified": "12"


### PR DESCRIPTION
### Motivation
- Improve the item creation dialog so item-type options are rendered in labeled optgroups and the group headings are styled consistently. 
- The previous manual grouping built `optgroup` elements from internal keys and didn't reliably preserve ordering, labels, or selection state when rebuilding the select. 

### Description
- Rewrote `buildItemTypeOptions` to construct a flat `options` array with `group` labels and to call `foundry.applications.fields.prepareSelectOptionGroups` to produce ordered optgroup data. 
- When creating DOM nodes the code now applies `option.selected` and `option.disabled` flags from the prepared data so the current selection and disabled state are preserved. 
- Localized supertype labels are computed and passed to the grouping helper to keep the displayed group headings correct. 
- Bumped `system.json` version from `2.347` to `2.348` per the repo auto-bump rule. 
- Modified file: `module/project-andromeda.mjs`; bumped manifest: `system.json`.

### Testing
- No automated tests were run in this change (ESLint/Jest not executed). 
- Manual validation was not performed in this environment because Foundry UI rendering is outside the test runner. 
- The change is limited to select construction logic and the version bump and does not introduce new localization keys.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978aecc638c832e891621c80cbf12e8)