### PR TITLE
Кнопка блокировки листа персонажа больше не доступна наблюдателям

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -817,6 +817,11 @@ export class ProjectAndromedaActorSheet extends FoundryActorSheet {
     const $header = this.element.find('.window-header').first();
     if (!$header.length) return;
 
+    if (!this.actor?.isOwner) {
+      $header.find('.andromeda-edit-mode-toggle').remove();
+      return;
+    }
+
     let $button = $header.find('.andromeda-edit-mode-toggle').first();
     if (!$button.length) {
       $button = $(`
@@ -853,6 +858,7 @@ export class ProjectAndromedaActorSheet extends FoundryActorSheet {
     event.preventDefault();
     event.stopPropagation();
     event.currentTarget?.blur?.();
+    if (!this.actor?.isOwner) return;
     this._editMode = !this._editMode;
     this._applySheetEditMode(this.element);
   }


### PR DESCRIPTION
## Что было сломано

Кнопка «заблокировать/разблокировать лист» (иконка замка в шапке листа персонажа) была видна и нажимаема любому, у кого есть доступ к листу — включая наблюдателей (observer), у которых должно быть только право на просмотр. Нажав её, наблюдатель мог перевести лист в режим редактирования и менять поля, хотя не должен был иметь такой возможности.

## Что я сделал

Добавил проверку прав: кнопка теперь появляется в шапке листа, только если у пользователя есть право владельца (owner) на этого персонажа — так же, как это уже работает для других элементов управления листом. Для ГМа кнопка по-прежнему видна (ГМ технически считается владельцем любого листа). На всякий случай добавил ту же проверку и в саму функцию переключения режима — если кнопка всё же где-то останется в интерфейсе (например, из-за кэша браузера), клик по ней ничего не сделает.

## Как я это проверил

- Прочитал диф свежим взглядом, проверил граничные случаи (ГМ, обычный владелец, наблюдатель, смена прав на лету — кнопка синхронизируется при каждой перерисовке листа).
- Прогнал `npm run lint` — чисто.
- Прогнал `npm test` — все тесты проходят (одна ранее существовавшая ошибка про форматирование JSON-каталогов не связана с этим изменением и присутствует на main независимо от моей правки).

## На что обратить внимание при игре

Риск минимальный — правка только сужает доступ. Стоит один раз проверить в реальной игре: наблюдатель (например, игрок, которому дали лист другого персонажа только на просмотр) не должен видеть замок в шапке листа, а владелец и ГМ — должны видеть и пользоваться им как раньше.